### PR TITLE
Upgrade to mail 2.5.4

### DIFF
--- a/valid_email2.gemspec
+++ b/valid_email2.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14.1"
   spec.add_development_dependency "coveralls"
-  spec.add_runtime_dependency "mail", '2.5.4'
+  spec.add_runtime_dependency "mail", '~> 2.5.4'
   spec.add_runtime_dependency "activemodel"
 end


### PR DESCRIPTION
This gem has a dependency on an old version of the mail gem. I have set it to the latest version available to resolve conflicts.
