### PR TITLE
Add desoz.com to disposable_email_domains.yml

### DIFF
--- a/config/disposable_email_domains.yml
+++ b/config/disposable_email_domains.yml
@@ -3727,6 +3727,7 @@
 - desmo.cf
 - desmo.ga
 - desmo.gq
+- desoz.com
 - despam.it
 - despammed.com
 - deszn1d5wl8iv0q.cf


### PR DESCRIPTION
Adds desoz.com to disposable_email_domains.yml. Seeing disposable spam accounts created with this domain.