### PR TITLE
Readme: Add disposable stub and extend the v3 update section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,16 @@ It is a good idea to stub out that validation in your test environment.
 Do so by adding this in your `spec_helper`:
 ```ruby
 config.before(:each) do
-  allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?) { true }
+  allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_return(true)
+end
+```
+
+Validating `disposable` e-mails triggers a `mx` validation alongside checking if
+the domain is disposable. The above stub does not apply to the `disposable`
+validation and should therefore be individually stubbed with:
+```ruby
+config.before(:each) do
+  allow_any_instance_of(ValidEmail2::Address).to receive(:mx_server_is_in?).and_return(false)
 end
 ```
 
@@ -117,6 +126,10 @@ vendor directory to the config directory. That means:
 
 `vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`  
 `vendor/whitelist.yml` -> `config/whitelisted_email_domains.yml`
+
+The `disposable` validation has been improved with a `mx` check. Apply the
+stub, as noted in the Test environment section, if your tests have slowed
+down or if they do not work without an internet connection.
 
 ## Upgrading to v2.0.0
 


### PR DESCRIPTION
- Improved the Readme to contain:
  - A stub for the `mx` part of the  `disposable` validation.
  - A note in the v3 update section regarding the above.
  - Change the stubs to use `and_return` instead of a block