### PR TITLE
add full address check for .@ as it is not allowed

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -34,7 +34,9 @@ module ValidEmail2
           # Domain may not have two consecutive dots
           domain !~ /\.{2,}/ &&
           # Domain may not start with a dot
-          domain !~ /^\./
+          domain !~ /^\./ &&
+          # Address may not contain a dot directly before @
+          address.address !~ /\.@/
       else
         false
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -75,6 +75,11 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo🙈@gmail.com")
       expect(user.valid?).to be_falsy
     end
+
+    it "is invalid if the domain contains .@ consecutively" do
+      user = TestUser.new(email: "foo.@gmail.com")
+      expect(user.valid?).to be_falsy
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
Email addresses are invalid if they have a '.@' consecutively and email systems will not send to addresses that are typed like that, but currently valid_email2 does not check for that issue. Hopefully you agree that this is a valid check that should be added and it can help out anyone else who may be having this issue :). 