### PR TITLE
xwaretech.com no longer points to mailinator

### DIFF
--- a/config/disposable_email_domains.yml
+++ b/config/disposable_email_domains.yml
@@ -14819,7 +14819,6 @@
 - xvcezxodtqzbvvcfw4a.gq
 - xvcezxodtqzbvvcfw4a.ml
 - xvcezxodtqzbvvcfw4a.tk
-- xwaretech.com
 - xwaretech.info
 - xwaretech.net
 - xwgpzgajlpw.cf


### PR DESCRIPTION
I'm using this domain for my company now with a commercial email provider (Fastmail). Previously we parked the domain and used it to dump junkmail in Mailinator. WPVulnDB and likely others blacklist domains in here. As we'd like to avoid being blacklisted in the future, I'm filing this pull request.