### PR TITLE
Validate that spaces cannot exist in the domain

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -6,7 +6,7 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
-    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_]/
+    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\s]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
 
     def initialize(address)

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -83,6 +83,11 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo.@gmail.com")
       expect(user.valid?).to be_falsy
     end
+
+    it "is invalid if the domain contains spaces" do
+      user = TestUser.new(email: "user@gmail .com")
+      expect(user.valid?).to be_falsy
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
After 3.0.1 was released the following passes validation:

```
user@gmail .com
```

Spaces should not allowed in the domain part.

https://en.wikipedia.org/wiki/Email_address#Examples

This PR fixes this.