### PR TITLE
Validate that domain name cannot begin or end with a dash

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -35,6 +35,10 @@ module ValidEmail2
           domain !~ /\.{2,}/ &&
           # Domain may not start with a dot
           domain !~ /^\./ &&
+          # Domain may not start with a dash
+          domain !~ /^-/ &&
+          # Domain name may not end with a dash
+          domain !~ /-\./ &&
           # Address may not contain a dot directly before @
           address.address !~ /\.@/
       else

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -83,6 +83,16 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo.@gmail.com")
       expect(user.valid?).to be_falsy
     end
+
+    it "is invalid if the domain begins with a dash" do
+      user = TestUser.new(email: "foo@-gmail.com")
+      expect(user.valid?).to be_falsy
+    end
+
+    it "is invalid if the domain name ends with a dash" do
+      user = TestUser.new(email: "foo@gmail-.com")
+      expect(user.valid?).to be_falsy
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
This PR corrects the following behavior in the gem:

Email addresses whose domain names begin or end with a "-" are currently being handled as valid email addresses.

For example:

* `foo@-gmail.com`
* `foo@gmail-.com`

Let me know what you think! Thanks in advance.