### PR TITLE
Ability to check for disposable domain without MX server check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,14 @@ To validate that the domain has a MX record:
 validates :email, 'valid_email_2/email': { mx: true }
 ```
 
-To validate that the domain is not a disposable email:
+To validate that the domain is not a disposable email (checks domain and MX server):
 ```ruby
 validates :email, 'valid_email_2/email': { disposable: true }
+```
+
+To validate that the domain is not a disposable email (checks domain only, does not check MX server):
+```ruby
+validates :email, 'valid_email_2/email': { disposable_domain: true }
 ```
 
 To validate that the domain is not a disposable email or a disposable email but whitelisted (under config/whitelisted_email_domains.yml):

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -23,26 +23,28 @@ module ValidEmail2
     end
 
     def valid?
-      return false if @parse_error
+      @valid ||= begin
+        return false if @parse_error
 
-      if address.domain && address.address == @raw_address
-        domain = address.domain
+        if address.domain && address.address == @raw_address
+          domain = address.domain
 
-        domain !~ PROHIBITED_DOMAIN_CHARACTERS_REGEX &&
-          # Domain needs to have at least one dot
-          domain =~ /\./ &&
-          # Domain may not have two consecutive dots
-          domain !~ /\.{2,}/ &&
-          # Domain may not start with a dot
-          domain !~ /^\./ &&
-          # Domain may not start with a dash
-          domain !~ /^-/ &&
-          # Domain name may not end with a dash
-          domain !~ /-\./ &&
-          # Address may not contain a dot directly before @
-          address.address !~ /\.@/
-      else
-        false
+          domain !~ PROHIBITED_DOMAIN_CHARACTERS_REGEX &&
+            # Domain needs to have at least one dot
+            domain =~ /\./ &&
+            # Domain may not have two consecutive dots
+            domain !~ /\.{2,}/ &&
+            # Domain may not start with a dot
+            domain !~ /^\./ &&
+            # Domain may not start with a dash
+            domain !~ /^-/ &&
+            # Domain name may not end with a dash
+            domain !~ /-\./ &&
+            # Address may not contain a dot directly before @
+            address.address !~ /\.@/
+        else
+          false
+        end
       end
     end
 
@@ -51,11 +53,15 @@ module ValidEmail2
     end
 
     def disposable?
-      valid? &&
-        (
-          domain_is_in?(ValidEmail2.disposable_emails) ||
-          mx_server_is_in?(ValidEmail2.disposable_emails)
-        )
+      disposable_domain? || disposable_mx_server?
+    end
+
+    def disposable_domain?
+      valid? && domain_is_in?(ValidEmail2.disposable_emails)
+    end
+
+    def disposable_mx_server?
+      valid? && mx_server_is_in?(ValidEmail2.disposable_emails)
     end
 
     def whitelisted?

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -24,6 +24,10 @@ module ValidEmail2
         error(record, attribute) && return if address.disposable?
       end
 
+      if options[:disposable_domain]
+        error(record, attribute) && return if address.disposable_domain?
+      end
+
       if options[:disposable_with_whitelist]
         error(record, attribute) && return if address.disposable? && !address.whitelisted?
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -18,6 +18,10 @@ class TestUserDisallowDisposable < TestModel
   validates :email, 'valid_email_2/email': { disposable: true }
 end
 
+class TestUserDisallowDisposableDomain < TestModel
+  validates :email, 'valid_email_2/email': { disposable_domain: true }
+end
+
 class TestUserDisallowDisposableWithWhitelist < TestModel
   validates :email, 'valid_email_2/email': { disposable_with_whitelist: true }
 end
@@ -111,19 +115,26 @@ describe ValidEmail2 do
       expect(user.valid?).to be_truthy
     end
 
-    it "is invalid if it's a disposable email" do
-      user = TestUserDisallowDisposable.new(email: "foo@#{disposable_domain}")
-      expect(user.valid?).to be_falsey
-    end
+    context "with disposable domain" do
+      it "is invalid with disposable domain" do
+        user = TestUserDisallowDisposable.new(email: "foo@#{disposable_domain}")
+        expect(user.valid?).to be_falsey
+      end
 
-    it "is invalid if the domain is a subdomain of a disposable domain" do
-      user = TestUserDisallowDisposable.new(email: "foo@bar.#{disposable_domain}")
-      expect(user.valid?).to be_falsey
-    end
+      it "is invalid with disposable domain even without mx server check" do
+        user = TestUserDisallowDisposableDomain.new(email: "foo@#{disposable_domain}")
+        expect(user.valid?).to be_falsey
+      end
 
-    it "allows example.com" do
-      user = TestUserDisallowDisposable.new(email: "foo@example.com")
-      expect(user.valid?).to be_truthy
+      it "is invalid if the domain is a subdomain of a disposable domain" do
+        user = TestUserDisallowDisposable.new(email: "foo@bar.#{disposable_domain}")
+        expect(user.valid?).to be_falsey
+      end
+
+      it "allows example.com" do
+        user = TestUserDisallowDisposable.new(email: "foo@example.com")
+        expect(user.valid?).to be_truthy
+      end
     end
 
     context "with domain that is not disposable but it's mx server is disposable" do


### PR DESCRIPTION
Users may want the ability to only check for a disposable domain, without an additional check for the MX server - there's a trade off between the value of the extra check for the MX server and the time saved by not making that check (because of the call to the DNS resolver).

Currently, you can only get this functionality by doing something like this:

```
a = ValidEmail2::Address.new(address)
disposable_domain = a.valid? && a.send(:domain_is_in?, ValidEmail2.disposable_emails)
```

My proposed PR would keep the `disposable?` method but also have separate methods for `disposable_domain?` and  `disposable_mx_server?`. You can also pass in `disposable_domain: true` into the `options` hash if you don't want to check the `mx_server` during the `disposable` check.