### PR TITLE
Adding forward slash to list of prohibited domain characters

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -6,7 +6,7 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
-    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\s]/
+    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
 
     def initialize(address)

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -89,6 +89,11 @@ describe ValidEmail2 do
       expect(user.valid?).to be_falsy
     end
 
+    it "is invalid if the domain contains a forward slash" do
+      user = TestUser.new(email: "user@gm/ail.com")
+      expect(user.valid?).to be_falsy
+    end
+
     it "is invalid if the domain begins with a dash" do
       user = TestUser.new(email: "foo@-gmail.com")
       expect(user.valid?).to be_falsy


### PR DESCRIPTION
Currently, the code allows for a forward slash in the email address domain, but this should be a prohibited character. This pull request addresses that.

**How to test**

If you set the changed `PROHIBITED_DOMAIN_CHARACTERS_REGEX` constant in `ValidEmail2::Address` back to its current value:

```PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\s]/```

you will see that the new test I have added fails.