### PR TITLE
Validate that locals do not include dots. Fixes #36

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -8,6 +8,7 @@ module ValidEmail2
 
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
+    DOT_DELIMITER = '.'.freeze
 
     def initialize(address)
       @parse_error = false
@@ -46,6 +47,10 @@ module ValidEmail2
           false
         end
       end
+    end
+
+    def dotted?
+      valid? && address.local.include?(DOT_DELIMITER)
     end
 
     def subaddressed?

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -16,6 +16,10 @@ module ValidEmail2
 
       error(record, attribute) && return unless address.valid?
 
+      if options[:disallow_dotted]
+        error(record, attribute) && return if address.dotted?
+      end
+
       if options[:disallow_subaddressing]
         error(record, attribute) && return if address.subaddressed?
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -6,6 +6,10 @@ class TestUser < TestModel
   validates :email, 'valid_email_2/email': true
 end
 
+class TestUserDotted < TestModel
+  validates :email, 'valid_email_2/email': { disallow_dotted: true }
+end
+
 class TestUserSubaddressing < TestModel
   validates :email, 'valid_email_2/email': { disallow_subaddressing: true }
 end
@@ -207,6 +211,18 @@ describe ValidEmail2 do
     end
   end
 
+  describe "with dotted validation" do
+    it "is valid when address does not contain dots" do
+      user = TestUserDotted.new(email: "johndoe@gmail.com")
+      expect(user.valid?).to be_truthy
+    end
+
+    it "is invalid when address cotains dots" do
+      user = TestUserDotted.new(email: "john.doe@gmail.com")
+      expect(user.valid?).to be_falsey
+    end
+  end
+
   describe "with subaddress validation" do
     it "is valid when address does not contain subaddress" do
       user = TestUserSubaddressing.new(email: "foo@gmail.com")
@@ -224,6 +240,18 @@ describe ValidEmail2 do
       user = TestUserMessage.new(email: "fakeemail")
       user.valid?
       expect(user.errors.full_messages).to include("Email custom message")
+    end
+  end
+
+  describe "#dotted?" do
+    it "is true when address local part contains a dot delimiter ('.')" do
+      email = ValidEmail2::Address.new("john.doe@gmail.com")
+      expect(email.dotted?).to be_truthy
+    end
+
+    it "is false when address local part contains a dot delimiter ('.')" do
+      email = ValidEmail2::Address.new("johndoe@gmail.com")
+      expect(email.dotted?).to be_falsey
     end
   end
 


### PR DESCRIPTION
- Resolves #36
- Add `disallow_dotted` option to enable validation of locals with dots
- Add `dotted?` method to check if a local includes a dot