### PR TITLE
Remove gmx.com and gmx.es from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -12822,10 +12822,8 @@ gmmx.com
 gmojl.com
 gmsdfhail.com
 gmssail.com
-gmx.com
 gmx.dns-cloud.net
 gmx.dnsabr.com
-gmx.es
 gmx.fr.nf
 gmx1mail.top
 gmxip8vet5glx2n9ld.cf


### PR DESCRIPTION
They belong to 1&1 Mail & Media GmbH