### PR TITLE
remove cock.li addresses

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -1052,7 +1052,6 @@
 41uno.com
 41uno.net
 41v1relaxn.com
-420blaze.it
 420pure.com
 42o.org
 43adsdzxcz.info
@@ -2185,7 +2184,6 @@ aaaaa7.pl
 aaaaa8.pl
 aaaaa9.pl
 aaaf.ru
-aaathats3as.com
 aaaw45e.com
 aabagfdgks.net
 aacxb.xyz
@@ -2884,7 +2882,6 @@ airjordanspascher1.com
 airjordansshoes2014.com
 airjordansstocker.com
 airknox.com
-airmail.cc
 airmail.tech
 airmailhub.com
 airmax-sale2013club.us
@@ -7362,7 +7359,6 @@ cobarekyo1.ml
 cobete.cf
 cobin2hood.com
 cobin2hood.company
-cocaine.ninja
 coccx1ajbpsz.cf
 coccx1ajbpsz.ga
 coccx1ajbpsz.gq
@@ -7370,9 +7366,6 @@ coccx1ajbpsz.ml
 coccx1ajbpsz.tk
 cochatz.ga
 cochranmail.men
-cock.email
-cock.li
-cock.lu
 coclaims.com
 coco.be
 cocochaneljapan.com
@@ -7852,7 +7845,6 @@ culdemamie.com
 cult-reno.ru
 cultmovie.com
 cum.sborra.tk
-cumallover.me
 cumangeblog.net
 cumanuallyo.com
 cumbeeclan.com
@@ -11348,7 +11340,6 @@ firef0x.gq
 firef0x.ml
 firef0x.tk
 fireflies.edu
-firemail.cc
 firemail.org.ua
 firemail.uz.ua
 firematchvn.cf
@@ -12459,7 +12450,6 @@ getaped.net
 getapet.net
 getasolarpanel.co.uk
 getaviciitickets.com
-getbackinthe.kitchen
 getbusinessontop.com
 getcleanskin.info
 getcoolmail.info
@@ -12867,7 +12857,6 @@ go2usa.info
 go2vpn.net
 goasfer.com
 goashmail.com
-goat.si
 gobet889.online
 gobet889bola.com
 gobet889skor.com
@@ -14011,7 +14000,6 @@ hitler-adolf.ga
 hitler-adolf.gq
 hitler-adolf.ml
 hitler-adolf.tk
-hitler.rocks
 hitlerbehna.com
 hitprice.co
 hitthatne.org.ua
@@ -14181,7 +14169,6 @@ hornet.ie
 hornyalwary.top
 horoskopde.com
 horsebarninfo.com
-horsefucker.org
 horsepoops.info
 horvathurtablahoz.ml
 host-info.com
@@ -19616,7 +19603,6 @@ memecituenakganasli.ml
 memecituenakganasli.tk
 memeil.top
 memem.uni.me
-memeware.net
 memkottawaprofilebacks.com
 memorygalore.com
 memp.net
@@ -20964,7 +20950,6 @@ nat4.us
 natachasteven.com
 nate.co.kr
 national-escorts.co.uk
-national.shitposting.agency
 nationalchampionshiplivestream.com
 nationalgardeningclub.com
 nationalsalesmultiplier.com
@@ -21373,7 +21358,6 @@ niepodam.pl
 nifone.ru
 nigdynieodpuszczaj.pl
 nigeria-nedv.ru
-nigge.rs
 nihongames.pl
 nijakvpsx.com
 nijmail.com
@@ -21756,7 +21740,6 @@ nub3zoorzrhomclef.tk
 nubescontrol.com
 nuctrans.org
 nude-vista.ru
-nuke.africa
 nullbox.info
 numanavale.com
 numweb.ru
@@ -24857,7 +24840,6 @@ ranmoi.net
 rao-network.com
 rao.kr
 rap-master.ru
-rape.lol
 rapenakyodilakoni.cf
 rapid-guaranteed-payday-loans.co.uk
 rapidcontentwizardofficial.com
@@ -28606,7 +28588,6 @@ tf5bh7wqi0zcus.ml
 tf5bh7wqi0zcus.tk
 tf7nzhw.com
 tfgphjqzkc.pl
-tfwno.gf
 tfzav6iptxcbqviv.cf
 tfzav6iptxcbqviv.ga
 tfzav6iptxcbqviv.gq
@@ -31229,7 +31210,6 @@ wagfused.com
 waggadistrict.com
 wahab.com
 wahch-movies.net
-waifu.club
 waitingjwo.com
 wajikethanh96ger.gq
 wakacje-e.pl


### PR DESCRIPTION
cock.li is a legitimate email provider which does not offer disposable addresses. 