### PR TITLE
Allow multiple addresses separated by comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ To validate create your own custom message:
 validates :email, 'valid_email_2/email': { message: "is not a valid email" }
 ```
 
+To allow multiple addresses separated by comma:
+```ruby
+validates :email, 'valid_email_2/email': { multiple: true }
+```
+
 All together:
 ```ruby
 validates :email, 'valid_email_2/email': { mx: true, disposable: true, disallow_subaddressing: true}

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -18,27 +18,27 @@ module ValidEmail2
       error(record, attribute) && return unless addresses.all?(&:valid?)
 
       if options[:disallow_dotted]
-        error(record, attribute) && return if addresses.all?(&:dotted?)
+        error(record, attribute) && return if addresses.any?(&:dotted?)
       end
 
       if options[:disallow_subaddressing]
-        error(record, attribute) && return if addresses.all?(&:subaddressed?)
+        error(record, attribute) && return if addresses.any?(&:subaddressed?)
       end
 
       if options[:disposable]
-        error(record, attribute) && return if addresses.all?(&:disposable?)
+        error(record, attribute) && return if addresses.any?(&:disposable?)
       end
 
       if options[:disposable_domain]
-        error(record, attribute) && return if addresses.all?(&:disposable_domain?)
+        error(record, attribute) && return if addresses.any?(&:disposable_domain?)
       end
 
       if options[:disposable_with_whitelist]
-        error(record, attribute) && return if addresses.all? { |address| address.disposable? && !address.whitelisted? }
+        error(record, attribute) && return if addresses.any? { |address| address.disposable? && !address.whitelisted? }
       end
 
       if options[:blacklist]
-        error(record, attribute) && return if addresses.all?(&:blacklisted?)
+        error(record, attribute) && return if addresses.any?(&:blacklisted?)
       end
 
       if options[:mx]

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,43 +5,44 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false, disallow_subaddressing: false }
+      { regex: true, disposable: false, mx: false, disallow_subaddressing: false, multiple: false }
     end
 
     def validate_each(record, attribute, value)
       return unless value.present?
       options = default_options.merge(self.options)
 
-      address = ValidEmail2::Address.new(value)
+      value_spitted = options[:multiple] ? value.split(',').map(&:strip) : [value]
+      addresses = value_spitted.map { |v| ValidEmail2::Address.new(v) }
 
-      error(record, attribute) && return unless address.valid?
+      error(record, attribute) && return unless addresses.all?(&:valid?)
 
       if options[:disallow_dotted]
-        error(record, attribute) && return if address.dotted?
+        error(record, attribute) && return if addresses.all?(&:dotted?)
       end
 
       if options[:disallow_subaddressing]
-        error(record, attribute) && return if address.subaddressed?
+        error(record, attribute) && return if addresses.all?(&:subaddressed?)
       end
 
       if options[:disposable]
-        error(record, attribute) && return if address.disposable?
+        error(record, attribute) && return if addresses.all?(&:disposable?)
       end
 
       if options[:disposable_domain]
-        error(record, attribute) && return if address.disposable_domain?
+        error(record, attribute) && return if addresses.all?(&:disposable_domain?)
       end
 
       if options[:disposable_with_whitelist]
-        error(record, attribute) && return if address.disposable? && !address.whitelisted?
+        error(record, attribute) && return if addresses.all? { |address| address.disposable? && !address.whitelisted? }
       end
 
       if options[:blacklist]
-        error(record, attribute) && return if address.blacklisted?
+        error(record, attribute) && return if addresses.all?(&:blacklisted?)
       end
 
       if options[:mx]
-        error(record, attribute) && return unless address.valid_mx?
+        error(record, attribute) && return unless addresses.all?(&:valid_mx?)
       end
     end
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -39,6 +39,10 @@ class TestUserMessage < TestModel
   validates :email, 'valid_email_2/email': { message: "custom message" }
 end
 
+class TestUserMultiple < TestModel
+  validates :email, 'valid_email_2/email': { multiple: true }
+end
+
 describe ValidEmail2 do
 
   let(:disposable_domain) { ValidEmail2.disposable_emails.first }
@@ -241,6 +245,20 @@ describe ValidEmail2 do
       user = TestUserMessage.new(email: "fakeemail")
       user.valid?
       expect(user.errors.full_messages).to include("Email custom message")
+    end
+  end
+
+  describe "with multiple addresses" do
+    it "tests each address for it's own" do
+      user = TestUserMultiple.new(email: "foo@gmail.com, bar@gmail.com")
+      expect(user.valid?).to be_truthy
+    end
+
+    context 'when one address is invalid' do
+      it "fails for all" do
+        user = TestUserMultiple.new(email: "foo@gmail.com, bar@123")
+        expect(user.valid?).to be_falsey
+      end
     end
   end
 


### PR DESCRIPTION
In some cases you want to check multiple email fields:

```ruby
class Invoice
  validates :receivers, 'valid_email_2/email': { mx: true, disposable: true, multiple: true }
end

Invoice.new(receivers: "invoices@google.com,accounting@google.com")
```

Each other option will check for each address.