### PR TITLE
Make prohibited_domain_characters_regex changeable

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -6,13 +6,16 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
+    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
     DOT_DELIMITER = '.'.freeze
 
-    self.class.attr_accessor :prohibited_domain_characters_regex
+    def self.prohibited_domain_characters_regex
+      @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
+    end
 
-    def self.reset
-      self.prohibited_domain_characters_regex = /[+!_\/\s'`]/
+    def self.prohibited_domain_characters_regex=(val)
+      @prohibited_domain_characters_regex = val
     end
 
     def initialize(address)
@@ -126,5 +129,3 @@ module ValidEmail2
     end
   end
 end
-
-ValidEmail2::Address.reset

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -6,9 +6,14 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
-    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
     DOT_DELIMITER = '.'.freeze
+
+    self.class.attr_accessor :prohibited_domain_characters_regex
+
+    def self.reset
+      self.prohibited_domain_characters_regex = /[+!_\/\s'`]/
+    end
 
     def initialize(address)
       @parse_error = false
@@ -30,7 +35,7 @@ module ValidEmail2
         if address.domain && address.address == @raw_address
           domain = address.domain
 
-          domain !~ PROHIBITED_DOMAIN_CHARACTERS_REGEX &&
+          domain !~ self.class.prohibited_domain_characters_regex &&
             # Domain needs to have at least one dot
             domain =~ /\./ &&
             # Domain may not have two consecutive dots
@@ -121,3 +126,5 @@ module ValidEmail2
     end
   end
 end
+
+ValidEmail2::Address.reset


### PR DESCRIPTION
On some SMTP servers you are not allowed to send mails to UTF-8 addresses. On my side its not allowed
to have "umlaut" in domain part.

This patch allows you to change the prohibited_domain_characters_regex such as a initalizer:

```ruby
# config/initializers/valid_email2.rb

ValidEmail2::Address.prohibited_domain_characters_regex = /[+!_\/\s'`äöüÖÄÜß]/
```