### PR TITLE
added an option that disallow a consecutive dots

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -45,6 +45,7 @@ module ValidEmail2
             !domain.start_with?('.') &&
             !domain.start_with?('-') &&
             !domain.include?('-.') &&
+            !address.local.include?('..') &&
             !address.local.end_with?('.')
         else
           false

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -87,6 +87,11 @@ describe ValidEmail2 do
       expect(user.valid?).to be_falsey
     end
 
+    it "is invalid if the address contains consecutive dots" do
+      user = TestUser.new(email: "foo..bar@gmail.com")
+      expect(user.valid?).to be_falsey
+    end
+
     it "is invalid if the email contains emoticons" do
       user = TestUser.new(email: "foo🙈@gmail.com")
       expect(user.valid?).to be_falsy


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Email_address#Validation_and_verification

`dot ., provided that it is not the first or last character and provided also that it does not appear consecutively (e.g., John..Doe@example.com is not allowed).[8]` 

Or you can see it in https://www.rfc-editor.org/rfc/inline-errata/rfc3696.html (search by "consecutive")