### PR TITLE
Whitelisted disposable domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,15 @@ To validate that the domain is not a disposable email (checks domain only, does 
 validates :email, 'valid_email_2/email': { disposable_domain: true }
 ```
 
-To validate that the domain is not a disposable email or a disposable email but whitelisted (under config/whitelisted_email_domains.yml):
+To validate that the domain is not a disposable email or a disposable email (checks domain and MX server) but whitelisted (under config/whitelisted_email_domains.yml):
 ```ruby
 validates :email, 'valid_email_2/email': { disposable_with_whitelist: true }
+```
+
+To validate that the domain is not a disposable email or a disposable email (checks domain only, does not check MX server) but whitelisted (under config/whitelisted_email_domains.yml):
+
+```ruby
+validates :email, 'valid_email_2/email': { disposable_domain_with_whitelist: true }
 ```
 
 To validate that the domain is not blacklisted (under config/blacklisted_email_domains.yml):

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -37,6 +37,10 @@ module ValidEmail2
         error(record, attribute) && return if addresses.any? { |address| address.disposable? && !address.whitelisted? }
       end
 
+      if options[:disposable_domain_with_whitelist]
+        error(record, attribute) && return if addresses.any? { |address| address.disposable_domain? && !address.whitelisted? }
+      end
+
       if options[:blacklist]
         error(record, attribute) && return if addresses.any?(&:blacklisted?)
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -195,8 +195,9 @@ describe ValidEmail2 do
 
       it "is valid if the domain is disposable but in the whitelist" do
         File.open(whitelist_file_path, "w") { |f| f.write [whitelist_domain].to_yaml }
+        set_whitelist
         user = TestUserDisallowDisposableWithWhitelist.new(email: "foo@#{whitelist_domain}")
-        expect(user.valid?).to be_falsey
+        expect(user.valid?).to be_truthy
       end
 
       it "is invalid if the domain is a disposable_domain and not in the whitelist" do


### PR DESCRIPTION
Hello,

I added a config option for `disposable_domain_with_whitelist` which allows for checking only `disposable_domain?` against the whitelist without checking for MX servers.

Also fixed a spec that was incorrect - `is valid if the domain is disposable but in the whitelist` was incorrectly passing that `user.valid?` was `falsy` due to `ValidEmail2.whitelist` being cached to an empty set.

I used `instance_variable_set` in the spec to avoid having to change `valid_email2.rb` to allow whitelist setting, I can do that instead if you prefer.