### PR TITLE
Remove vp.com from disposable_email_domains.txt

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -31027,7 +31027,6 @@ voyagebirmanie.net
 voyancegratuite10min.com
 voyeurseite.info
 vozmivtop.ru
-vp.com
 vp.ycare.de
 vpanel.ru
 vpc608a0.pl


### PR DESCRIPTION
`vp.com` does not appear to be a disposable domain. We've had a legitimate user try and sign up with this email address and I also verified this using Mailgun's validator.

![Screen Shot 2020-10-12 at 3 16 53 PM](https://user-images.githubusercontent.com/2474416/95792108-0568ff80-0ca0-11eb-9570-fd4704c3b1d8.png)
