### PR TITLE
added ability to disallow special chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ To validate that email does not contain a dot before the @:
 validates :email, 'valid_email_2/email': { disallow_dotted: true }
 ```
 
+To validate that email does not contain any of the special chars (``#!$%'*+-/=?^`.{|}~``):
+```ruby
+validates :email, 'valid_email_2/email': { disallow_special_chars: true }
+```
+
 To validate create your own custom message:
 ```ruby
 validates :email, 'valid_email_2/email': { message: "is not a valid email" }

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -9,6 +9,7 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
     DOT_DELIMITER = '.'.freeze
+    SPECIAL_CHARS = '#\!$%\'*+-/=?^`.{|}~'.freeze
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
@@ -55,6 +56,10 @@ module ValidEmail2
 
     def dotted?
       valid? && address.local.include?(DOT_DELIMITER)
+    end
+
+    def contain_special_chars?
+      valid? && address_contain_special_chars?(address.local, SPECIAL_CHARS)
     end
 
     def subaddressed?
@@ -114,6 +119,10 @@ module ValidEmail2
       return false if email.nil?
 
       email.each_char.any? { |char| char.bytesize > 1 }
+    end
+
+    def address_contain_special_chars?(address, special_chars)
+      special_chars.chars.any? { |char| address.include?(char) }
     end
 
     def mx_servers

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -21,6 +21,10 @@ module ValidEmail2
         error(record, attribute) && return if addresses.any?(&:dotted?)
       end
 
+      if options[:disallow_special_chars]
+        error(record, attribute) && return if addresses.any?(&:contain_special_chars?)
+      end
+
       if options[:disallow_subaddressing]
         error(record, attribute) && return if addresses.any?(&:subaddressed?)
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -11,6 +11,10 @@ class TestUserDotted < TestModel
   validates :email, 'valid_email_2/email': { disallow_dotted: true }
 end
 
+class TestUserSpecialChars < TestModel
+  validates :email, 'valid_email_2/email': { disallow_special_chars: true }
+end
+
 class TestUserSubaddressing < TestModel
   validates :email, 'valid_email_2/email': { disallow_subaddressing: true }
 end
@@ -224,6 +228,23 @@ describe ValidEmail2 do
 
     it "is invalid when address cotains dots" do
       user = TestUserDotted.new(email: "john.doe@gmail.com")
+      expect(user.valid?).to be_falsey
+    end
+  end
+
+  describe "with special chars validation" do
+    it "is valid when address does not contain special chars" do
+      user = TestUserSpecialChars.new(email: "johndoe@gmail.com")
+      expect(user.valid?).to be_truthy
+    end
+
+    it "is invalid when address cotains special chars #" do
+      user = TestUserSpecialChars.new(email: "john#doe@gmail.com")
+      expect(user.valid?).to be_falsey
+    end
+
+    it "is invalid when address cotains special chars !" do
+      user = TestUserSpecialChars.new(email: "john!doe@gmail.com")
       expect(user.valid?).to be_falsey
     end
   end


### PR DESCRIPTION
We have problem that many services (such as gmail, yahoo, activecampaign, etc) don`t allow special chars in email and I thin that its a good idea to have ability disallow special chars while email validation