### PR TITLE
Add strict_mx validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,13 @@ class User < ActiveRecord::Base
 end
 ```
 
-To validate that the domain has a MX record:
+To validate that the domain has an MX record or A record:
 ```ruby
 validates :email, 'valid_email_2/email': { mx: true }
+```
+To validate strictly that the domain has an MX record:
+```ruby
+validates :email, 'valid_email_2/email': { strict_mx: true }
 ```
 
 To validate that the domain is not a disposable email (checks domain and MX server):
@@ -109,6 +113,7 @@ address = ValidEmail2::Address.new("lisinge@gmail.com")
 address.valid? => true
 address.disposable? => false
 address.valid_mx? => true
+address.valid_strict_mx? => true
 address.subaddressed? => false
 ```
 
@@ -120,6 +125,7 @@ Do so by adding this in your `spec_helper`:
 ```ruby
 config.before(:each) do
   allow_any_instance_of(ValidEmail2::Address).to receive(:valid_mx?).and_return(true)
+  allow_any_instance_of(ValidEmail2::Address).to receive(:valid_strict_mx?).and_return(true)
 end
 ```
 

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -85,6 +85,12 @@ module ValidEmail2
     def valid_mx?
       return false unless valid?
 
+      mx_or_a_servers.any?
+    end
+
+    def valid_strict_mx?
+      return false unless valid?
+
       mx_servers.any?
     end
 
@@ -119,7 +125,12 @@ module ValidEmail2
 
     def mx_servers
       @mx_servers ||= Resolv::DNS.open do |dns|
-        mx_servers = dns.getresources(address.domain, Resolv::DNS::Resource::IN::MX)
+        dns.getresources(address.domain, Resolv::DNS::Resource::IN::MX)
+      end
+    end
+
+    def mx_or_a_servers
+      @mx_or_a_servers ||= Resolv::DNS.open do |dns|
         (mx_servers.any? && mx_servers) ||
           dns.getresources(address.domain, Resolv::DNS::Resource::IN::A)
       end

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,7 +5,7 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false, disallow_subaddressing: false, multiple: false }
+      { regex: true, disposable: false, mx: false, strict_mx: false, disallow_subaddressing: false, multiple: false }
     end
 
     def validate_each(record, attribute, value)
@@ -47,6 +47,10 @@ module ValidEmail2
 
       if options[:mx]
         error(record, attribute) && return unless addresses.all?(&:valid_mx?)
+      end
+
+      if options[:strict_mx]
+        error(record, attribute) && return unless addresses.all?(&:valid_strict_mx?)
       end
     end
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -19,6 +19,10 @@ class TestUserMX < TestModel
   validates :email, 'valid_email_2/email': { mx: true }
 end
 
+class TestUserStrictMX < TestModel
+  validates :email, 'valid_email_2/email': { strict_mx: true }
+end
+
 class TestUserDisallowDisposable < TestModel
   validates :email, 'valid_email_2/email': { disposable: true }
 end
@@ -249,6 +253,23 @@ describe ValidEmail2 do
 
     it "is invalid if no mx records are found" do
       user = TestUserMX.new(email: "foo@subdomain.gmail.com")
+      expect(user.valid?).to be_falsey
+    end
+  end
+
+  describe "with strict mx validation" do
+    it "is valid if mx records are found" do
+      user = TestUserStrictMX.new(email: "foo@gmail.com")
+      expect(user.valid?).to be_truthy
+    end
+
+    it "is invalid if A records are found but no mx records are found" do
+      user = TestUserStrictMX.new(email: "foo@ghs.google.com")
+      expect(user.valid?).to be_falsey
+    end
+
+    it "is invalid if no mx records are found" do
+      user = TestUserStrictMX.new(email: "foo@subdomain.gmail.com")
       expect(user.valid?).to be_falsey
     end
   end


### PR DESCRIPTION
This resolves #118 by allowing the user to validate either strictly on the presence of MX records, or by following a strict reading of RFC 5321 and considering an A record as a valid mail destination.