### PR TITLE
Add biyac.com as disposable email domain

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -5177,6 +5177,7 @@ bitwhites.top
 bitx.nl
 bitymails.us
 biuro-naprawcze.pl
+biyac.com
 biz.st
 bizalem.com
 bizalon.com


### PR DESCRIPTION
Adding `biyac.com` to disposable email list.

This web [https://tempail.com](https://tempail.com) is offering disposable email under the domain `biyac.com`

![image](https://user-images.githubusercontent.com/14993662/116162351-e0952080-a6f5-11eb-9cdd-1ff7ce10e6f0.png)
