### PR TITLE
fix: adding mailpoof.com to the list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -19076,6 +19076,7 @@ mailpick.biz
 mailplus.pl
 mailpm.live
 mailpooch.com
+mailpoof.com
 mailpost.comx.cf
 mailpost.gq
 mailpremium.net


### PR DESCRIPTION
Original site:  https://mailpoof.com/