### PR TITLE
Fix an issue with validating an email array

### DIFF
--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -12,8 +12,7 @@ module ValidEmail2
       return unless value.present?
       options = default_options.merge(self.options)
 
-      value_spitted = options[:multiple] ? value.split(',').map(&:strip) : [value]
-      addresses = value_spitted.map { |v| ValidEmail2::Address.new(v) }
+      addresses = sanitized_values(value).map { |v| ValidEmail2::Address.new(v) }
 
       error(record, attribute) && return unless addresses.all?(&:valid?)
 
@@ -52,6 +51,18 @@ module ValidEmail2
       if options[:strict_mx]
         error(record, attribute) && return unless addresses.all?(&:valid_strict_mx?)
       end
+    end
+
+    def sanitized_values(input)
+      options = default_options.merge(self.options)
+
+      if options[:multiple]
+        email_list = input.is_a?(Array) ? input : input.split(',')
+      else
+        email_list = [input]
+      end
+
+      email_list.reject(&:empty?).map(&:strip)
     end
 
     def error(record, attribute)

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -312,6 +312,11 @@ describe ValidEmail2 do
       expect(user.valid?).to be_truthy
     end
 
+    it "tests each address from an array" do
+      user = TestUserMultiple.new(email: %w[foo@gmail.com bar@gmail.com])
+      expect(user.valid?).to be_truthy
+    end
+
     context 'when one address is invalid' do
       it "fails for all" do
         user = TestUserMultiple.new(email: "foo@gmail.com, bar@123")


### PR DESCRIPTION
If one tried to pass an array of emails for validation instead of a csv
string, validation would fail, as it would try to apply string methods
to an array. This fix supports both csv strings and email arrays.