### PR TITLE
Add herrain.com as disposable email domain

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -33858,3 +33858,4 @@ zzz.co
 zzz.com
 zzzmail.pl
 zzzzzzzzzzzzz.com
+herrain.com


### PR DESCRIPTION
In our database, some users started to by-pass our validation using this domain `herrain.com`