### PR TITLE
Remove onit.com from the disposable domain list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -22437,7 +22437,6 @@ onewaymail.com
 ongc.ga
 onhrrzqsubu.pl
 oninmail.com
-onit.com
 onkyo1.com
 onlatedotcom.info
 onlimail.com


### PR DESCRIPTION
It is a valid company domain.