### PR TITLE
Remove asics.com from the disposable domain list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -3901,7 +3901,6 @@ asianflushtips.info
 asiangangsta.site
 asiapmail.club
 asiarap.usa.cc
-asics.com
 asicshoesmall.com
 asicsonshop.org
 asicsrunningsale.com


### PR DESCRIPTION
This is a legitimate company website.