### PR TITLE
Remove freemail.hu from the disposable domain list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -12852,7 +12852,6 @@ freelymail.com
 freemail-host.info
 freemail.bid
 freemail.co.pl
-freemail.hu
 freemail.men
 freemail.ms
 freemail.nx.cninfo.net


### PR DESCRIPTION
This is a legitimate free email service.