### PR TITLE
Remove 139.com from the disposable domain list.

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -340,7 +340,6 @@
 12wqeza.com
 1337.email
 1369.ru
-139.com
 13dk.net
 13sasytkgb0qobwxat.cf
 13sasytkgb0qobwxat.ga


### PR DESCRIPTION
This is a free email service which runs by China Mobile.