### PR TITLE
ValidEmail2::Address#valid? always returns a boolean, also for invalid addresses

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -38,14 +38,12 @@ module ValidEmail2
       return @valid unless @valid.nil?
       return false  if @parse_error
 
-      @valid = address.domain &&
-               address.address == @raw_address &&
-               valid_domain? &&
-               valid_address?
+      @valid = valid_domain? && valid_address?
     end
 
     def valid_domain?
       domain = address.domain
+      return false if domain.nil?
 
       domain !~ self.class.prohibited_domain_characters_regex &&
         domain.include?('.') &&
@@ -56,6 +54,8 @@ module ValidEmail2
     end
 
     def valid_address?
+      return false if address.address != @raw_address
+
       !address.local.include?('..') &&
         !address.local.end_with?('.') &&
         !address.local.start_with?('.')

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ValidEmail2::Address do
+  describe "#valid?" do
+    it "is valid" do
+      address = described_class.new("foo@bar123.com")
+      expect(address.valid?).to be true
+    end
+
+    it "is invalid if email is nil" do
+      address = described_class.new(nil)
+      expect(address.valid?).to be false
+    end
+
+    it "is invalid if email is empty" do
+      address = described_class.new(" ")
+      expect(address.valid?).to be false
+    end
+
+    it "is invalid if domain is missing" do
+      address = described_class.new("foo")
+      expect(address.valid?).to be false
+    end
+
+    it "is invalid if email cannot be parsed" do
+      address = described_class.new("<>")
+      expect(address.valid?).to be false
+    end
+
+    it "is invalid if email contains emoticons" do
+      address = described_class.new("foo🙈@gmail.com")
+      expect(address.valid?).to be false
+    end
+  end
+end


### PR DESCRIPTION
This change makes sure that `ValidEmail2::Address#valid?` always returns a boolean, and not nil which it currently returns when the input is not valid (e.g. empty or no domain).

I added a few specs for `ValidEmail2::Address` and explicitly test for true/false (not truthy/falsey).