### PR TITLE
Clarify `disallow_dotted` applies to anywhere before the @

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To validate that email is not subaddressed:
 validates :email, 'valid_email_2/email': { disallow_subaddressing: true }
 ```
 
-To validate that email does not contain a dot before the @:
+To validate that email does not contain a dot anywhere before the @:
 ```ruby
 validates :email, 'valid_email_2/email': { disallow_dotted: true }
 ```


### PR DESCRIPTION
I'm currently using the extremely simple Devise regex (`/\A[^@\s]+@[^@\s]+\z/`) for validating emails, and an email like `foo.@example.com` (notice the dot right before @)  snuck in as valid when it's not.

In exploring ways to catch this, I stumbled onto this library and on first read of the docs, I took the `disallow_dotted` option to mean literally a dot right before @ (as my example showed), as opposed to anywhere before the @. The fact that it's an optional feature, and not the default, gave me pause of whether a dot right before the @ might sometimes be valid if it's the user's choice to enable this or not, sending me into the code to understand how the option is implemented.

Now it's clear that it rejects the email if there's dots anywhere before the @, not just literally right before. Hopefully this clarifies things for the next person and saves them some time.