### PR TITLE
Remove domains that are not disposable domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -8282,7 +8282,6 @@
 8a818.club
 8a9itx.online
 8aj.net
-8alias.com
 8americain.fr
 8angue9wtjv4dwa9.com
 8avz.net
@@ -8423,7 +8422,6 @@
 8rskf3xpyq.ml
 8rskf3xpyq.tk
 8rygn.com
-8shield.net
 8t0sznngp6aowxsrj.cf
 8t0sznngp6aowxsrj.ga
 8t0sznngp6aowxsrj.gq
@@ -12628,7 +12626,6 @@ alectronik.com
 aledestrya671.tk
 aledrioroots.youdontcare.com
 alee.co.pl
-aleeas.com
 aleelma686.ml
 aleen.emailind.com
 aleepapalae.gq
@@ -41161,7 +41158,6 @@ drakeslansdowne.com
 drakor.pro
 drakorfor.me
 draktar.online
-dralias.com
 dralselahi.com
 dram.network
 drama.tw
@@ -76724,7 +76720,6 @@ lilly.co
 lillymeadows.com
 lilnx.net
 lilo.me
-lilo.org
 lilspam.com
 lilyclears.com
 lilyjeter.com
@@ -115996,7 +115991,6 @@ simplejourneyguide.com
 simplelifetimeincome.com
 simplelifthub.com
 simplelogin.co
-simplelogin.fr
 simplemail.in
 simplemail.top
 simplemailserver.bid
@@ -116903,7 +116897,6 @@ sljcsb.com
 slkdjf.com
 slkfewkkfgt.pl
 slkjghsx77sx.ru
-slmail.me
 slmshf.cf
 slmtracker.com
 slobodanetivana.com


### PR DESCRIPTION
These domains are not disposable domains :
- dralias.com
- aleeas.com
- 8alias.com
- 8shield.net
- slmail.me
- simplelogin.fr
- lilo.org

Resolves issue #199 