### PR TITLE
Remove option 'regex' from default_options as it doesn't seem to be used

### DIFF
--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,7 +5,7 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false, strict_mx: false, disallow_subaddressing: false, multiple: false, dns_timeout: 5 }
+      { disposable: false, mx: false, strict_mx: false, disallow_subaddressing: false, multiple: false, dns_timeout: 5 }
     end
 
     def validate_each(record, attribute, value)


### PR DESCRIPTION
"regex: true" appears to not be used in the code base, so removed it.

test plan: ran tests, tests pass. 