### PR TITLE
Remove mozmail.com from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -96709,7 +96709,6 @@ mozillafirefox.ml
 mozillafirefox.tk
 mozillamail.com
 mozillamailcom.com
-mozmail.com
 mozmail.info
 mozzasiatopizzavalencia.com
 mozzinovo.club


### PR DESCRIPTION
This fixes #202 