### PR TITLE
Remove simplelogin.co from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -128855,7 +128855,6 @@ simpleitsecurity.info
 simplejourneyguide.com
 simplelifetimeincome.com
 simplelifthub.com
-simplelogin.co
 simplemail.in
 simplemail.top
 simplemailserver.bid


### PR DESCRIPTION
Fix (partially) #211 by allowing custom domains managed by [SimpleLogin](https://simplelogin.io/).