### PR TITLE
Remove Simplelogin aliases from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -19948,7 +19948,6 @@ bachoa.xyz
 bachpanglobal.com
 bachuem.com
 bachus-dava.com
-bacillation.slmail.me
 bacillsagc.space
 bacinj.com
 back-painsos.org
@@ -43277,7 +43276,6 @@ dinoschristou.com
 dinosloto7.ru
 dinospacegame.com
 dinospizza-kilkenny.com
-dinostrength.aleeas.com
 dinotek.top
 dinoza.pro
 dinozorcocuk.com
@@ -45429,7 +45427,6 @@ dpluse.net
 dpm5g8.us
 dpmchqfi.shop
 dpmcinternational.com
-dpmtunnel.slmail.me
 dpmwybaff.shop
 dpnf.us
 dpnwoyov.shop
@@ -56696,7 +56693,6 @@ forumies.com
 forumk.net
 forumoxy.com
 forumrou.com
-forums.aleeas.com
 forumtroo.site
 forusine.net
 forvetbahis.org
@@ -56833,7 +56829,6 @@ foxeer.ru
 foxgroups.xyz
 foxhaq.site
 foxhawks.com
-foxieblu.slmail.me
 foxiomail.com
 foxja.com
 foxkingdom.ru
@@ -91089,7 +91084,6 @@ mapyatirim.com
 mapycyfrowe-bydgoszcz.pl
 maqus-opl.best
 mar-notification.com
-mar.slmail.me
 mara.jessica.webmailious.top
 marabalan.cf
 marabalan.ga
@@ -103306,7 +103300,6 @@ nuk.trillania.com
 nukahome.com
 nuke.africa
 nukemc.biz
-nul.slmail.me
 nuliferecords.com
 nuligepe.site
 null.cd
@@ -104513,7 +104506,6 @@ official-site-admiralx.xyz
 official-sunveno.ru
 official-tomsshoes.net
 official-trailer.ru
-official.aleeas.com
 official.republican
 official.site
 official.vote
@@ -146031,7 +146023,6 @@ ulzlfh.us
 um0vwn.us
 um2dq7.us
 um85.com
-uma.slmail.me
 uma3.be
 umaasa.com
 umail.net
@@ -159648,7 +159639,6 @@ youngandjuicy.net
 youngaudiences.us
 youngbluekennels.com
 youngbrofessionals.com
-youngchief.aleeas.com
 youngcrew.ga
 youngforevers.com
 younghemp.com


### PR DESCRIPTION
Follow-up to #212, fix (partially) #211 by allowing aliases managed by [SimpleLogin](https://simplelogin.io/).