### PR TITLE
Add `dns_nameserver` option for mx checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,16 @@ To validate strictly that the domain has an MX record:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true }
 ```
-`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups.  To
+`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups. To
 override this timeout, specify a `dns_timeout` option:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true, dns_timeout: 10 }
+```
+
+Any checks that require DNS resolution will use the default `Resolv::DNS` nameservers for DNS lookups. To
+override these, specify a `dns_nameserver` option:
+```ruby
+validates :email, 'valid_email_2/email': { mx: true, dns_nameserver: ['8.8.8.8', '8.8.4.4'] }
 ```
 
 To validate that the domain is not a disposable email (checks domain and MX server):
@@ -125,7 +131,7 @@ address.subaddressed? => false
 ### Test environment
 
 If you are validating `mx` then your specs will fail without an internet connection.
-It is a good idea to stub out that validation in your test environment.  
+It is a good idea to stub out that validation in your test environment.
 Do so by adding this in your `spec_helper`:
 ```ruby
 config.before(:each) do
@@ -146,7 +152,7 @@ This gem is tested against currently supported Ruby and Rails versions. For an u
 In version v3.0.0 I decided to move __and__ rename the config files from the
 vendor directory to the config directory. That means:
 
-`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`  
+`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`
 `vendor/whitelist.yml` -> `config/whitelisted_email_domains.yml`
 
 The `disposable` validation has been improved with a `mx` check. Apply the
@@ -155,7 +161,7 @@ down or if they do not work without an internet connection.
 
 ## Upgrading to v2.0.0
 
-In version 1.0 of valid_email2 we only defined the `email` validator.  
+In version 1.0 of valid_email2 we only defined the `email` validator.
 But since other gems also define a `email` validator this can cause some unintended
 behaviours and emails that shouldn't be valid are regarded valid because the
 wrong validator is used by rails.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This gem is tested against currently supported Ruby and Rails versions. For an u
 In version v3.0.0 I decided to move __and__ rename the config files from the
 vendor directory to the config directory. That means:
 
-`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`
+`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`  
 `vendor/whitelist.yml` -> `config/whitelisted_email_domains.yml`
 
 The `disposable` validation has been improved with a `mx` check. Apply the
@@ -161,7 +161,7 @@ down or if they do not work without an internet connection.
 
 ## Upgrading to v2.0.0
 
-In version 1.0 of valid_email2 we only defined the `email` validator.
+In version 1.0 of valid_email2 we only defined the `email` validator.  
 But since other gems also define a `email` validator this can cause some unintended
 behaviours and emails that shouldn't be valid are regarded valid because the
 wrong validator is used by rails.

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ To validate strictly that the domain has an MX record:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true }
 ```
-`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups. To
-override this timeout, specify a `dns_timeout` option:
+`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups.  
+To override this timeout, specify a `dns_timeout` option:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true, dns_timeout: 10 }
 ```
 
-Any checks that require DNS resolution will use the default `Resolv::DNS` nameservers for DNS lookups. To
-override these, specify a `dns_nameserver` option:
+Any checks that require DNS resolution will use the default `Resolv::DNS` nameservers for DNS lookups.  
+To override these, specify a `dns_nameserver` option:
 ```ruby
 validates :email, 'valid_email_2/email': { mx: true, dns_nameserver: ['8.8.8.8', '8.8.4.4'] }
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ address.subaddressed? => false
 ### Test environment
 
 If you are validating `mx` then your specs will fail without an internet connection.
-It is a good idea to stub out that validation in your test environment.
+It is a good idea to stub out that validation in your test environment.  
 Do so by adding this in your `spec_helper`:
 ```ruby
 config.before(:each) do

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -25,10 +25,8 @@ module ValidEmail2
       @raw_address = address
       @dns_timeout = dns_timeout
 
-      if dns_nameserver
-        @dns_config_info = Resolv::DNS::Config.default_config_hash
-        @dns_config_info[:nameserver] = dns_nameserver
-      end
+      @resolv_config = Resolv::DNS::Config.default_config_hash
+      @resolv_config[:nameserver] = dns_nameserver if dns_nameserver
 
       begin
         @address = Mail::Address.new(address)

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -137,7 +137,7 @@ module ValidEmail2
     end
 
     def mx_servers
-      @mx_servers ||= Resolv::DNS.open(@dns_config_info) do |dns|
+      @mx_servers ||= Resolv::DNS.open(@resolv_config) do |dns|
         dns.timeouts = @dns_timeout
         dns.getresources(address.domain, Resolv::DNS::Resource::IN::MX)
       end

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,14 +5,14 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { disposable: false, mx: false, strict_mx: false, disallow_subaddressing: false, multiple: false, dns_timeout: 5 }
+      { disposable: false, mx: false, strict_mx: false, disallow_subaddressing: false, multiple: false, dns_timeout: 5, dns_nameserver: nil }
     end
 
     def validate_each(record, attribute, value)
       return unless value.present?
       options = default_options.merge(self.options)
 
-      addresses = sanitized_values(value).map { |v| ValidEmail2::Address.new(v, options[:dns_timeout]) }
+      addresses = sanitized_values(value).map { |v| ValidEmail2::Address.new(v, options[:dns_timeout], options[:dns_nameserver]) }
 
       error(record, attribute) && return unless addresses.all?(&:valid?)
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -28,7 +28,7 @@ class TestUserMXDnsTimeout < TestModel
 end
 
 class TestUserMXDnsFailingTimeout < TestModel
-  validates :email, 'valid_email_2/email': { mx: true, dns_timeout: 0.001 }
+  validates :email, 'valid_email_2/email': { mx: true, dns_timeout: Float::MIN }
 end
 
 class TestUserMXDnsNameserver < TestModel


### PR DESCRIPTION
Adds an option for easily customising the DNS resolver that is used for checking A and MX records.
If no option is given, it will use all current defaults.