### PR TITLE
Remove net.ua from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -103330,7 +103330,6 @@ net-piyango.biz
 net-privichkam.ru
 net-solution.info
 net.ee
-net.ua
 net100limite.ml
 net191.com
 net1mail.com

--- a/pull_mailchecker_emails.rb
+++ b/pull_mailchecker_emails.rb
@@ -5,7 +5,7 @@ require "yaml"
 require "json"
 require "net/http"
 
-whitelisted_emails = %w(
+whitelisted_emails = %w[
   onet.pl poczta.onet.pl fastmail.fm hushmail.com
   hush.ai hush.com hushmail.me naver.com qq.com example.com
   yandex.net gmx.com gmx.es webdesignspecialist.com.au vp.com
@@ -15,13 +15,14 @@ whitelisted_emails = %w(
   passinbox.com passfwd.com passmail.com passmail.net
   duck.com mozmail.com dralias.com 8alias.com 8shield.net
   mailinblack.com anonaddy.com anonaddy.me addy.io privaterelay.appleid.com appleid.com
-)
+  net.ua
+]
 
 existing_emails = File.open("config/disposable_email_domains.txt") { |f| f.read.split("\n") }
 
 remote_emails = [
   "https://raw.githubusercontent.com/FGRibreau/mailchecker/master/list.txt",
-  "https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.txt",
+  "https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.txt"
 ].flat_map do |url|
   resp = Net::HTTP.get_response(URI.parse(url))
 
@@ -30,4 +31,4 @@ end
 
 result_emails = (existing_emails + remote_emails).map(&:strip).uniq.sort - whitelisted_emails
 
-File.open("config/disposable_email_domains.txt", "w") { |f| f.write result_emails.join("\n") }
+File.write("config/disposable_email_domains.txt", result_emails.join("\n"))


### PR DESCRIPTION
net.ua is a root domain and should not mark as disposable email domain.
It blocks all domains in that zone.

https://www.net.ua/uk/