### PR TITLE
Add support for friendly email address formats (Foo <foo@bar.com>)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ To validate strictly that the domain has an MX record:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true }
 ```
-`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups.  
+`strict_mx` and `mx` both default to a 5 second timeout for DNS lookups.
 To override this timeout, specify a `dns_timeout` option:
 ```ruby
 validates :email, 'valid_email_2/email': { strict_mx: true, dns_timeout: 10 }
 ```
 
-Any checks that require DNS resolution will use the default `Resolv::DNS` nameservers for DNS lookups.  
+Any checks that require DNS resolution will use the default `Resolv::DNS` nameservers for DNS lookups.
 To override these, specify a `dns_nameserver` option:
 ```ruby
 validates :email, 'valid_email_2/email': { mx: true, dns_nameserver: ['8.8.8.8', '8.8.4.4'] }
@@ -109,6 +109,11 @@ To allow multiple addresses separated by comma:
 validates :email, 'valid_email_2/email': { multiple: true }
 ```
 
+To allow email addresses that include a display name (e.g. `John Doe <john.doe@example.com>`):
+```ruby
+validates :email, 'valid_email_2/email': { allow_display_name: true }
+```
+
 All together:
 ```ruby
 validates :email, 'valid_email_2/email': { mx: true, disposable: true, disallow_subaddressing: true}
@@ -131,7 +136,7 @@ address.subaddressed? => false
 ### Test environment
 
 If you are validating `mx` then your specs will fail without an internet connection.
-It is a good idea to stub out that validation in your test environment.  
+It is a good idea to stub out that validation in your test environment.
 Do so by adding this in your `spec_helper`:
 ```ruby
 config.before(:each) do
@@ -152,7 +157,7 @@ This gem is tested against currently supported Ruby and Rails versions. For an u
 In version v3.0.0 I decided to move __and__ rename the config files from the
 vendor directory to the config directory. That means:
 
-`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`  
+`vendor/blacklist.yml` -> `config/blacklisted_email_domains.yml`
 `vendor/whitelist.yml` -> `config/whitelisted_email_domains.yml`
 
 The `disposable` validation has been improved with a `mx` check. Apply the
@@ -161,7 +166,7 @@ down or if they do not work without an internet connection.
 
 ## Upgrading to v2.0.0
 
-In version 1.0 of valid_email2 we only defined the `email` validator.  
+In version 1.0 of valid_email2 we only defined the `email` validator.
 But since other gems also define a `email` validator this can cause some unintended
 behaviours and emails that shouldn't be valid are regarded valid because the
 wrong validator is used by rails.

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -58,8 +58,12 @@ module ValidEmail2
     end
 
     def valid_address?
-      return false if address.address != @raw_address && !@allow_display_name
-      return false if address.format != @raw_address
+      if @allow_display_name
+        address_only = @raw_address.split('<').last.split('>').first
+        return false if address.address != address_only
+      else
+        return false if address.address != @raw_address
+      end
 
       !address.local.include?('..') &&
         !address.local.end_with?('.') &&

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -20,10 +20,11 @@ module ValidEmail2
       @prohibited_domain_characters_regex = val
     end
 
-    def initialize(address, dns_timeout = 5, dns_nameserver = nil)
+    def initialize(address, dns_timeout: 5, dns_nameserver: nil, allow_display_name: false)
       @parse_error = false
       @raw_address = address
       @dns_timeout = dns_timeout
+      @allow_display_name = allow_display_name
 
       @resolv_config = Resolv::DNS::Config.default_config_hash
       @resolv_config[:nameserver] = dns_nameserver if dns_nameserver
@@ -57,7 +58,8 @@ module ValidEmail2
     end
 
     def valid_address?
-      return false if address.address != @raw_address
+      return false if address.address != @raw_address && !@allow_display_name
+      return false if address.format != @raw_address
 
       !address.local.include?('..') &&
         !address.local.end_with?('.') &&

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -12,7 +12,7 @@ module ValidEmail2
       return unless value.present?
       options = default_options.merge(self.options)
 
-      addresses = sanitized_values(value).map { |v| ValidEmail2::Address.new(v, options[:dns_timeout], options[:dns_nameserver]) }
+      addresses = sanitized_values(value).map { |v| ValidEmail2::Address.new(v, dns_timeout: options[:dns_timeout], dns_nameserver: options[:dns_nameserver], allow_display_name: options[:allow_display_name]) }
 
       error(record, attribute) && return unless addresses.all?(&:valid?)
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -508,6 +508,36 @@ describe ValidEmail2 do
       expect(user.valid?).to be_truthy
     end
 
+    it "is false when the name has a '<' character" do
+      user = TestUserAllowDisplayName.new(email: "Friendly < Name <foo@gmail.com>")
+      expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
+    end
+
+    it "is false when the email has a '<' character" do
+      user = TestUserAllowDisplayName.new(email: "Name <fo<o@gmail.com>")
+      expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
+    end
+
+    it "is false when the email has additional separator characters" do
+      user = TestUserAllowDisplayName.new(email: "Name <fo<o@gmail.c>om>")
+      expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
+    end
+
+    it "is false when the email has an additional '>' character in the TLD" do
+      user = TestUserAllowDisplayName.new(email: "Name <foo@gmail.c>om>")
+      expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
+    end
+
+    it "is false when the separator characters are missing" do
+      user = TestUserAllowDisplayName.new(email: "Name foo@gmail.com")
+      expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
+    end
+
     it "is true when the display name contains a dot or special character" do
       user = TestUserAllowDisplayName.new(email: "Friendly.O'Toole <foo@gmail.com>")
       expect(user.valid?).to be_truthy
@@ -516,6 +546,7 @@ describe ValidEmail2 do
     it "is false when the friendly name contains unicode characters" do
       user = TestUserAllowDisplayName.new(email: "Jürgen Klopp <footy@gmail.com>")
       expect(user.valid?).to be_falsey
+      expect(user.errors.full_messages).to contain_exactly("Email is invalid")
     end
 
     context "with used with other flags" do

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -75,6 +75,14 @@ class TestUserMultiple < TestModel
   validates :email, 'valid_email_2/email': { multiple: true }
 end
 
+class TestUserAllowDisplayName < TestModel
+  validates :email, 'valid_email_2/email': { allow_display_name: true }
+end
+
+class TestUserDisplayNameMultiple < TestModel
+  validates :email, 'valid_email_2/email': { allow_display_name: true, multiple: true }
+end
+
 describe ValidEmail2 do
 
   let(:disposable_domain) { ValidEmail2.disposable_emails.first }
@@ -486,6 +494,37 @@ describe ValidEmail2 do
     it "is false when address local part contains a recipient delimiter ('+')" do
       email = ValidEmail2::Address.new("foo@gmail.com")
       expect(email.subaddressed?).to be_falsey
+    end
+  end
+
+  describe "with display_name allowed" do
+    it "is true with email address only" do
+      user = TestUserAllowDisplayName.new(email: "foo@gmail.com")
+      expect(user.valid?).to be_truthy
+    end
+
+    it "is true when address contains a friendly_name" do
+      user = TestUserAllowDisplayName.new(email: "Friendly Name <foo@gmail.com>")
+      expect(user.valid?).to be_truthy
+    end
+
+    context "with used with other flags" do
+      it "mutliple tests each address for it's own" do
+        user = TestUserDisplayNameMultiple.new(email: "Foo <foo@gmail.com>, Bar <bar@gmail.com>")
+        expect(user.valid?).to be_truthy
+      end
+
+      it "multiple tests each address from an array" do
+        user = TestUserDisplayNameMultiple.new(email: ["Foo <foo@gmail.com>", "Bar <bar@gmail.com>"])
+        expect(user.valid?).to be_truthy
+      end
+
+      context 'with multiple when one address is invalid' do
+        it "fails for all" do
+          user = TestUserDisplayNameMultiple.new(email: "Foo <foo@gmail.com>, Bar <bar@123>")
+          expect(user.valid?).to be_falsey
+        end
+      end
     end
   end
 end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -508,6 +508,16 @@ describe ValidEmail2 do
       expect(user.valid?).to be_truthy
     end
 
+    it "is true when the display name contains a dot or special character" do
+      user = TestUserAllowDisplayName.new(email: "Friendly.O'Toole <foo@gmail.com>")
+      expect(user.valid?).to be_truthy
+    end
+
+    it "is false when the friendly name contains unicode characters" do
+      user = TestUserAllowDisplayName.new(email: "Jürgen Klopp <footy@gmail.com>")
+      expect(user.valid?).to be_falsey
+    end
+
     context "with used with other flags" do
       it "mutliple tests each address for it's own" do
         user = TestUserDisplayNameMultiple.new(email: "Foo <foo@gmail.com>, Bar <bar@gmail.com>")


### PR DESCRIPTION
This PR adds a new option to the rails validator that allows email addresses including a display name such as "First Last <email@example.com>". 

NOTE: This does make a change under the covers to use named parameters in the `ValidEmail2::Address` initializer, which may affect compatibility with older versions of Ruby. 