### PR TITLE
remove valid domain https://check-mail.org/domain/kommespaeter.de/

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -83538,7 +83538,6 @@ komferry.com
 komfu.com
 komilbek90.site
 komkomp.ru
-kommespaeter.de
 kommunity.biz
 kommv.cc.be
 komnatnye-rasteniya.ru


### PR DESCRIPTION
According to our customer and check-domain this is not disposable https://check-mail.org/domain/kommespaeter.de/