### PR TITLE
remove directbox.com

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -44958,7 +44958,6 @@ direct-mail.info
 direct-mail.top
 direct.ditchly.com
 direct2thehome.com
-directbox.com
 directcala.com
 directdepositviaach.com
 directhatch.com


### PR DESCRIPTION
A user complained that he could not register. The domain is supposed to be OK https://check-mail.org/domain/directbox.com/