### PR TITLE
Add missing linebreak to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This gem is tested against currently supported Ruby and Rails versions. For an u
 
 In version v5.3.0 the config directory files were renamed as follows:
 
-`config/blacklisted_email_domains.yml` -> `config/deny_listed_email_domains.yml`
+`config/blacklisted_email_domains.yml` -> `config/deny_listed_email_domains.yml`  
 `config/whitelisted_email_domains.yml` -> `config/allow_listed_email_domains.yml`
 
 You won't need to make any changes yourself if you're installing this version for the first time. For individuals updating from earlier versions, make sure to update the file namings as per the above. In future versions this will be a breaking change.


### PR DESCRIPTION
Just noticed that this is the consequence of [my update](9df0bf8c9912721b007e5a6acc67f533ca560c9f) to the README:

<img width="752" alt="Screenshot 2024-09-01 at 10 48 10" src="https://github.com/user-attachments/assets/e33208a9-c163-4992-8e07-480ec5cd5695">

This PR changes the above to the following:

<img width="677" alt="Screenshot 2024-09-01 at 10 47 54" src="https://github.com/user-attachments/assets/250639f4-1ff1-4463-a155-0afc7303639a">
