### PR TITLE
Remove  embarqmail.com from disposible list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -51296,7 +51296,6 @@ embaeqmail.com
 embalaje.us
 embaramail.com
 embarq.net
-embarqmail.com
 embarqumail.com
 embassyofcoffee.de
 embatqmail.com

--- a/pull_mailchecker_emails.rb
+++ b/pull_mailchecker_emails.rb
@@ -15,7 +15,7 @@ allow_listed_emails = %w[
   passinbox.com passfwd.com passmail.com passmail.net
   duck.com mozmail.com dralias.com 8alias.com 8shield.net
   mailinblack.com anonaddy.com anonaddy.me addy.io privaterelay.appleid.com appleid.com
-  net.ua kommespaeter.de alpenjodel.de my.id web.id directbox.com
+  net.ua kommespaeter.de alpenjodel.de my.id web.id directbox.com embarqmail.com
 ]
 
 existing_emails = File.open("config/disposable_email_domains.txt") { |f| f.read.split("\n") }


### PR DESCRIPTION
A customer me informed that this is a valid business domain. Apparently it was Sprint, then sprint changed its name to Embarq, and now it is grandfathered in and managed by Centurylink.
