### PR TITLE
fix(email_validator): handle trailing whitespace in emails

### DIFF
--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -57,12 +57,12 @@ module ValidEmail2
       options = default_options.merge(self.options)
 
       if options[:multiple]
-        email_list = input.is_a?(Array) ? input : input.split(',')
+        email_list = input.is_a?(Array) ? input : input.split(',').map(&:strip)
       else
         email_list = [input]
       end
 
-      email_list.reject(&:empty?).map(&:strip)
+      email_list.reject(&:empty?)
     end
 
     def error(record, attribute)

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -158,6 +158,11 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo@gmail-.com")
       expect(user.valid?).to be_falsy
     end
+
+    it "is invalid with trailing whitespace" do
+      user = TestUser.new(email: "foo@example.com ")
+      expect(user.valid?).to be_falsey
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
- Updated email_validator to strip trailing whitespace from emails when the `multiple` option is enabled.
- Added a test case to ensure emails with trailing whitespace are considered invalid.

Stripping on sanitized values make sense with the multiple option is activated and the input is an string. Otherwise it can lead into emails being stored with trailing whitespace on the DB.