### PR TITLE
fix: disallow # in domain

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -9,7 +9,7 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
-    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'`]/
+    PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -163,6 +163,11 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo@example.com ")
       expect(user.valid?).to be_falsey
     end
+
+    it "is invalid if domain contains #" do
+      user = TestUser.new(email: "foo@example.com#")
+      expect(user.valid?).to be_falsey
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
As far as I can tell, # is not valid in a domain name, so this adds it to the list of diallowed chars.

It seems only ASCII a-z,0-9, and - but not at start or end are allowed. Perhaps we want to rejig it from a disallow to an allow list?