### PR TITLE
Fix false multibyte character detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ address.valid_strict_mx? => true
 address.subaddressed? => false
 ```
 
+If you want to allow multibyte characters, set it explicitly.
+
+```ruby
+ValidEmail2::Address.permitted_multibyte_characters_regex = /[ÆæØøÅåÄäÖöÞþÐð]/
+```
+
+
 ### Test environment
 
 If you are validating `mx` then your specs will fail without an internet connection.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ If you want to allow multibyte characters, set it explicitly.
 ValidEmail2::Address.permitted_multibyte_characters_regex = /[ÆæØøÅåÄäÖöÞþÐð]/
 ```
 
-
 ### Test environment
 
 If you are validating `mx` then your specs will fail without an internet connection.

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -140,8 +140,13 @@ module ValidEmail2
     def address_contain_emoticons?
       return false if @raw_address.nil?
 
-      @raw_address.each_char.any? do |char|
-        char.bytesize > 1 && char !~ self.class.permitted_multibyte_characters_regex
+      multibyte_chars = @raw_address.scan(/./).select { |char| char.bytesize > 1 }
+      return false if multibyte_chars.empty?
+
+      return true if self.class.permitted_multibyte_characters_regex.nil?
+
+      multibyte_chars.any? do |char|
+        !self.class.permitted_multibyte_characters_regex.match?(char)
       end
     end
 

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -13,6 +13,7 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
+    SCANDINAVIAN_REGEX = /[ÆæØøÅåÄäÖöÞþÐð]/
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
@@ -133,7 +134,9 @@ module ValidEmail2
     def address_contain_emoticons?
       return false if @raw_address.nil?
 
-      @raw_address.scan(Unicode::Emoji::REGEX).length >= 1
+      @raw_address.each_char.any? do |char|
+        char.bytesize > 1 && char !~ SCANDINAVIAN_REGEX
+      end
     end
 
     def resolv_config

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -12,7 +12,6 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
-    SCANDINAVIAN_REGEX = /[ÆæØøÅåÄäÖöÞþÐð]/
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
@@ -20,6 +19,14 @@ module ValidEmail2
 
     def self.prohibited_domain_characters_regex=(val)
       @prohibited_domain_characters_regex = val
+    end
+
+    def self.permitted_multibyte_characters_regex
+      @permitted_multibyte_characters_regex
+    end
+
+    def self.permitted_multibyte_characters_regex=(val)
+      @permitted_multibyte_characters_regex = val
     end
 
     def initialize(address, dns_timeout = 5, dns_nameserver = nil)
@@ -134,7 +141,7 @@ module ValidEmail2
       return false if @raw_address.nil?
 
       @raw_address.each_char.any? do |char|
-        char.bytesize > 1 && char !~ SCANDINAVIAN_REGEX
+        char.bytesize > 1 && char !~ self.class.permitted_multibyte_characters_regex
       end
     end
 

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -3,7 +3,6 @@
 require "valid_email2"
 require "resolv"
 require "mail"
-require "unicode/emoji"
 require "valid_email2/dns_records_cache"
 
 module ValidEmail2

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -41,7 +41,7 @@ module ValidEmail2
         @parse_error = true
       end
 
-      @parse_error ||= address_contain_emoticons?
+      @parse_error ||= address_contain_multibyte_characters?
     end
 
     def valid?
@@ -137,7 +137,7 @@ module ValidEmail2
       }
     end
 
-    def address_contain_emoticons?
+    def address_contain_multibyte_characters?
       return false if @raw_address.nil?
 
       multibyte_chars = @raw_address.scan(/./).select { |char| char.bytesize > 1 }

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -140,14 +140,9 @@ module ValidEmail2
     def address_contain_multibyte_characters?
       return false if @raw_address.nil?
 
-      multibyte_chars = @raw_address.scan(/./).select { |char| char.bytesize > 1 }
-      return false if multibyte_chars.empty?
+      return false if @raw_address.ascii_only?
 
-      return true if self.class.permitted_multibyte_characters_regex.nil?
-
-      multibyte_chars.any? do |char|
-        !self.class.permitted_multibyte_characters_regex.match?(char)
-      end
+      @raw_address.each_char.any? { |char| char.bytesize > 1 && char !~ self.class.permitted_multibyte_characters_regex }
     end
 
     def resolv_config

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -34,6 +34,11 @@ describe ValidEmail2::Address do
       expect(address.valid?).to be false
     end
 
+    it "is invalid if it contains Japanese characters" do
+      address = described_class.new("あいうえお@example.com")
+      expect(address.valid?).to be false
+    end
+
     it "is valid if it contains special scandinavian characters" do
       address = described_class.new("jørgen@email.dk")
       expect(address.valid?).to eq true

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -39,9 +39,20 @@ describe ValidEmail2::Address do
       expect(address.valid?).to be false
     end
 
-    it "is valid if it contains special scandinavian characters" do
+    it "is invalid if it contains special scandinavian characters" do
       address = described_class.new("jørgen@email.dk")
-      expect(address.valid?).to eq true
+      expect(address.valid?).to eq false
+    end
+
+    context "permitted_multibyte_characters_regex is set" do
+      before do
+        described_class.permitted_multibyte_characters_regex = /[ÆæØøÅåÄäÖöÞþÐð]/
+      end
+
+      it "is valid if it contains special scandinavian characters" do
+        address = described_class.new("jørgen@email.dk")
+        expect(address.valid?).to eq true
+      end
     end
   end
 

--- a/valid_email2.gemspec
+++ b/valid_email2.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_runtime_dependency "mail", "~> 2.5"
   spec.add_runtime_dependency "activemodel", ">= 6.0"
-  spec.add_runtime_dependency "unicode-emoji", "~> 3.7.0"
 end


### PR DESCRIPTION
https://github.com/micke/valid_email2/pull/257
In this PR, changes are being made to prevent Scandinavian characters from being judged as emoji.

However, this method had a large impact on the validity of email addresses, and for example, email addresses containing Japanese characters were erroneously determined to be VALID.(The expected value is INVALID).

I made the following changes.

- Basically, do not allow multibyte characters
- If you want to allow multibyte characters, set it explicitly

```ruby
ValidEmail2::Address.permitted_multibyte_characters_regex = /[ÆæØøÅåÄäÖöÞþÐð]/
```