### PR TITLE
Add YAML format example and API reference link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ validates :email, 'valid_email_2/email': { mx: true, disposable: true, disallow_
 > Note that this gem will let an empty email pass through so you will need to
 > add `presence: true` if you require an email
 
+
 ### Use without ActiveModel
 
 ```ruby
@@ -127,6 +128,8 @@ address.valid_mx? => true
 address.valid_strict_mx? => true
 address.subaddressed? => false
 ```
+
+For other APIs, please check [lib/valid_email2/address.rb](https://github.com/micke/valid_email2/blob/main/lib/valid_email2/address.rb).
 
 If you want to allow multibyte characters, set it explicitly.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ To validate that the domain is not on the deny list (under config/deny_listed_em
 validates :email, 'valid_email_2/email': { deny_list: true }
 ```
 
+The allow_listed_email_domains.yml and deny_listed_email_domains.yml can be written as follows:
+
+```yml
+# config/deny_listed_email_domains.yml
+- denied1.example.com
+- denied2.example.com
+```
+
 To validate that email is not subaddressed:
 ```ruby
 validates :email, 'valid_email_2/email': { disallow_subaddressing: true }


### PR DESCRIPTION
@micke 

Thank you for this wonderful gem.
This gem has been very helpful for our product.

I made two additions to the README.
First, I added an example of how to write YAML files. While testing it, I found the specification to be very simple, but some OSS might require nested structures. I clarified this point in the documentation.
Second, since the methods available in the Address class were not all listed, I added a link to address.rb.

Please could you review.
Thanks.