### PR TITLE
Fix `domain_is_in?` for deeply nested subdomain

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -119,10 +119,12 @@ module ValidEmail2
       address_domain = address.domain.downcase
       return true if domain_list.include?(address_domain)
 
-      i = address_domain.index('.')
-      return false unless i
+      while i = address_domain.index('.')
+        address_domain = address_domain[(i + 1)..-1]
+        return true if domain_list.include?(address_domain)
+      end
 
-      domain_list.include?(address_domain[(i + 1)..-1])
+      false
     end
 
     def mx_server_is_in?(domain_list)

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -29,7 +29,7 @@ module ValidEmail2
       @permitted_multibyte_characters_regex = val
     end
 
-    def initialize(address, dns_timeout = 5, dns_nameserver = nil, domain_hierarchy_max_depth = 2)
+    def initialize(address, dns_timeout = 5, dns_nameserver = nil, domain_hierarchy_max_depth: 3)
       @parse_error = false
       @raw_address = address
       @dns_timeout = dns_timeout
@@ -124,7 +124,7 @@ module ValidEmail2
       return false if tokens.length < 3
 
       max_depth = [@domain_hierarchy_max_depth, tokens.length].min
-      (3..max_depth).each do |depth|
+      (2..max_depth).each do |depth|
         partial_domain = tokens.reverse.first(depth).reverse.join('.')
         return true if domain_list.include?(partial_domain)
       end

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -125,7 +125,7 @@ module ValidEmail2
 
       max_depth = [@domain_hierarchy_max_depth, tokens.length].min
       (2..max_depth).each do |depth|
-        partial_domain = tokens.reverse.first(depth).reverse.join('.')
+        partial_domain = tokens.last(depth).join('.')
         return true if domain_list.include?(partial_domain)
       end
 

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -124,7 +124,7 @@ module ValidEmail2
       return false if tokens.length < 3
 
       max_depth = [@domain_hierarchy_max_depth, tokens.length].min
-      (2..max_depth).each do |depth|
+      (3..max_depth).each do |depth|
         partial_domain = tokens.reverse.first(depth).reverse.join('.')
         return true if domain_list.include?(partial_domain)
       end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -56,6 +56,30 @@ describe ValidEmail2::Address do
     end
   end
 
+  describe "#disposable_domain?" do
+    let(:disposable_domain) { ValidEmail2.disposable_emails.first }
+
+    it "is true if the domain is in the disposable_emails list" do
+      address = described_class.new("foo@#{disposable_domain}")
+      expect(address.disposable_domain?).to eq true
+    end
+
+    it "is true if the domain is a subdomain of a disposable domain" do
+      address = described_class.new("foo@sub.#{disposable_domain}")
+      expect(address.disposable_domain?).to eq true
+    end
+
+    it "is true if the domain is a deeply nested subdomain of a disposable domain" do
+      address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}")
+      expect(address.disposable_domain?).to eq true
+    end
+
+    it "is false if the domain is not in the disposable_emails list" do
+      address = described_class.new("foo@example.com")
+      expect(address.disposable_domain?).to eq false
+    end
+  end
+
   describe "caching" do
     let(:email_address) { "example@ymail.com" }
     let(:email_instance) { described_class.new(email_address) }
@@ -181,7 +205,7 @@ describe ValidEmail2::Address do
             email_instance.valid_strict_mx?
           end
 
-          it "calls the the MX servers lookup" do    
+          it "calls the the MX servers lookup" do
             email_instance.valid_strict_mx?
 
             expect(Resolv::DNS).to have_received(:open).once
@@ -308,8 +332,8 @@ describe ValidEmail2::Address do
             stub_const("ValidEmail2::DnsRecordsCache::MAX_CACHE_SIZE", 0)
           end
 
-          it "prunes the cache" do 
-            expect(dns_records_cache_instance).to receive(:prune_cache).once 
+          it "prunes the cache" do
+            expect(dns_records_cache_instance).to receive(:prune_cache).once
 
             email_instance.valid_mx?
           end
@@ -331,7 +355,7 @@ describe ValidEmail2::Address do
             end
           end
         end
-      end    
+      end
     end
   end
 end

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -78,6 +78,25 @@ describe ValidEmail2::Address do
       address = described_class.new("foo@example.com")
       expect(address.disposable_domain?).to eq false
     end
+
+    context "when the disposable domain has subdomains" do
+      let(:disposable_domain) { ValidEmail2.disposable_emails.find { |domain| domain.count(".") > 1 } }
+
+      it "is true if the domain is in the disposable_emails list" do
+        address = described_class.new("foo@#{disposable_domain}")
+        expect(address.disposable_domain?).to eq true
+      end
+
+      it "is true if the domain is a subdomain of a disposable domain" do
+        address = described_class.new("foo@sub.#{disposable_domain}")
+        expect(address.disposable_domain?).to eq true
+      end
+
+      it "is true if the domain is a deeply nested subdomain of a disposable domain" do
+        address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}")
+        expect(address.disposable_domain?).to eq true
+      end
+    end
   end
 
   describe "caching" do

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -57,43 +57,47 @@ describe ValidEmail2::Address do
   end
 
   describe "#disposable_domain?" do
-    let(:disposable_domain) { ValidEmail2.disposable_emails.first }
+    let(:domain_hierarchy_max_depth) { 10 }
 
-    it "is true if the domain is in the disposable_emails list" do
-      address = described_class.new("foo@#{disposable_domain}")
-      expect(address.disposable_domain?).to eq true
-    end
+    context "when the disposable domain does not have subdomains" do
+      let(:disposable_domain) { ValidEmail2.disposable_emails.find { |domain| domain.count(".") == 1 } }
 
-    it "is true if the domain is a subdomain of a disposable domain" do
-      address = described_class.new("foo@sub.#{disposable_domain}")
-      expect(address.disposable_domain?).to eq true
-    end
+      it "is true if the domain is in the disposable_emails list" do
+        address = described_class.new("foo@#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
+        expect(address.disposable_domain?).to eq true
+      end
 
-    it "is true if the domain is a deeply nested subdomain of a disposable domain" do
-      address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}")
-      expect(address.disposable_domain?).to eq true
-    end
+      it "is true if the domain is a subdomain of a disposable domain" do
+        address = described_class.new("foo@sub.#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
+        expect(address.disposable_domain?).to eq true
+      end
 
-    it "is false if the domain is not in the disposable_emails list" do
-      address = described_class.new("foo@example.com")
-      expect(address.disposable_domain?).to eq false
+      it "is true if the domain is a deeply nested subdomain of a disposable domain" do
+        address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
+        expect(address.disposable_domain?).to eq true
+      end
+
+      it "is false if the domain is not in the disposable_emails list" do
+        address = described_class.new("foo@example.com", nil, nil, domain_hierarchy_max_depth:)
+        expect(address.disposable_domain?).to eq false
+      end
     end
 
     context "when the disposable domain has subdomains" do
       let(:disposable_domain) { ValidEmail2.disposable_emails.find { |domain| domain.count(".") > 1 } }
 
       it "is true if the domain is in the disposable_emails list" do
-        address = described_class.new("foo@#{disposable_domain}")
+        address = described_class.new("foo@#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
         expect(address.disposable_domain?).to eq true
       end
 
       it "is true if the domain is a subdomain of a disposable domain" do
-        address = described_class.new("foo@sub.#{disposable_domain}")
+        address = described_class.new("foo@sub.#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
         expect(address.disposable_domain?).to eq true
       end
 
       it "is true if the domain is a deeply nested subdomain of a disposable domain" do
-        address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}")
+        address = described_class.new("foo@sub3.sub2.sub1.#{disposable_domain}", nil, nil, domain_hierarchy_max_depth:)
         expect(address.disposable_domain?).to eq true
       end
     end


### PR DESCRIPTION
@micke 

Hi,
Thank you for reviewing and merging [my previous PR](https://github.com/micke/valid_email2/pull/266).

I found that there are some email address patterns that cannot be detected when using `domain_is_in?` in `disposable_domain?`.

For example, when `disposable_domain.com` is included in the blocklist:

- `foo@disposable_domain.com`
- `foo@sub.disposable_domain.com`

can be detected, but:

- `foo@sub2.sub1.disposable_domain.com`

with two or more nested subdomains cannot be detected.

Therefore, I modified `domain_is_in?` to detect deeply nested subdomains as well.
I've also added RSpec test cases for this.

Thanks.