### PR TITLE
remove buildingradar.com from disposable list

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -29426,7 +29426,6 @@ buildingandtech.com
 buildingfastmuscles.com
 buildinghopekeystone.org
 buildinglanes.shop
-buildingradar.com
 buildingstogo.com
 buildlimun.com
 buildlogicsllc.com


### PR DESCRIPTION
This is a PR to address the request to remove buildingradar.com from the disposable email list in this issue:

https://github.com/micke/valid_email2/issues/281

CC: @eldenw28
