### PR TITLE
Cache mx_server_is_in? to speed up disposable_mx_server?

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -3,6 +3,7 @@
 require "valid_email2"
 require "mail"
 require "valid_email2/dns"
+require "digest"
 
 module ValidEmail2
   class Address
@@ -11,6 +12,7 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
+    @cache_mx_server_is_in = {}
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
@@ -130,15 +132,24 @@ module ValidEmail2
     end
 
     def mx_server_is_in?(domain_list)
-      @dns.mx_servers(address.domain).any? { |mx_server|
+      mx_servers = @dns.mx_servers(address.domain)
+
+      cache_key = generate_mx_cache_key(domain_list, mx_servers)
+
+      return self.class.cache_mx_server_is_in[cache_key] if !cache_key.nil? && self.class.cache_mx_server_is_in.key?(cache_key)
+
+      result = mx_servers.any? do |mx_server|
         return false unless mx_server.respond_to?(:exchange)
 
         mx_server = mx_server.exchange.to_s
 
-        domain_list.any? { |domain|
+        domain_list.any? do |domain|
           mx_server.end_with?(domain) && mx_server =~ /\A(?:.+\.)*?#{domain}\z/
-        }
-      }
+        end
+      end
+
+      self.class.cache_mx_server_is_in[cache_key] = result unless cache_key.nil?
+      result
     end
 
     def address_contain_multibyte_characters?
@@ -152,6 +163,19 @@ module ValidEmail2
     def null_mx?
       mx_servers = @dns.mx_servers(address.domain)
       mx_servers.length == 1 && mx_servers.first.preference == 0 && mx_servers.first.exchange.length == 0
+    end
+
+    def generate_mx_cache_key(domain_list, mx_servers)
+      return nil if mx_servers.length == 0 || domain_list.length == 0
+
+      mx_servers_str = mx_servers.map(&:exchange).map(&:to_s).sort.join
+      return address.domain if mx_servers_str == ""
+
+      "#{domain_list.object_id}_#{domain_list.length}_#{mx_servers_str.downcase}"
+    end
+
+    def self.cache_mx_server_is_in
+      @cache_mx_server_is_in
     end
   end
 end

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -3,7 +3,6 @@
 require "valid_email2"
 require "mail"
 require "valid_email2/dns"
-require "digest"
 
 module ValidEmail2
   class Address
@@ -12,7 +11,6 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
-    @cache_mx_server_is_in = {}
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX

--- a/lib/valid_email2/dns.rb
+++ b/lib/valid_email2/dns.rb
@@ -37,7 +37,7 @@ module ValidEmail2
         mx_server = mx_server.exchange.to_s
 
         domain_list.any? do |disposable_domain|
-          mx_server.end_with?(disposable_domain) && mx_server =~ /\A(?:.+\.)*?#{disposable_domain}\z/
+          mx_server.end_with?(disposable_domain) && mx_server.match?(/\A(?:.+\.)*?#{disposable_domain}\z/)
         end
       end
 
@@ -89,10 +89,10 @@ module ValidEmail2
     end
 
     def generate_mx_cache_key(domain, domain_list, mx_servers)
-      return nil if mx_servers.empty? || domain_list.empty?
+      return if mx_servers.empty? || domain_list.empty?
 
       mx_servers_str = mx_servers.map(&:exchange).map(&:to_s).sort.join
-      return domain if mx_servers_str == ""
+      return domain if mx_servers_str.empty?
 
       "#{domain_list.object_id}_#{domain_list.length}_#{mx_servers_str.downcase}"
     end

--- a/lib/valid_email2/dns.rb
+++ b/lib/valid_email2/dns.rb
@@ -4,7 +4,7 @@ module ValidEmail2
   class Dns
     MAX_CACHE_SIZE = 1_000
     CACHE = {}
-
+    MX_SERVERS_CACHE = {}
     CacheEntry = Struct.new(:records, :cached_at, :ttl)
 
     def self.prune_cache
@@ -24,6 +24,26 @@ module ValidEmail2
 
     def mx_servers(domain)
       fetch(domain, Resolv::DNS::Resource::IN::MX)
+    end
+
+    def mx_servers_disposable?(domain, domain_list)
+      servers = mx_servers(domain)
+      cache_key = generate_mx_cache_key(domain, domain_list, servers)
+      return MX_SERVERS_CACHE[cache_key] if !cache_key.nil? && MX_SERVERS_CACHE.key?(cache_key)
+
+      result = servers.any? do |mx_server|
+        return false unless mx_server.respond_to?(:exchange)
+
+        mx_server = mx_server.exchange.to_s
+
+        domain_list.any? do |disposable_domain|
+          mx_server.end_with?(disposable_domain) && mx_server =~ /\A(?:.+\.)*?#{disposable_domain}\z/
+        end
+      end
+
+      MX_SERVERS_CACHE[cache_key] = result unless cache_key.nil?
+
+      result
     end
 
     def a_servers(domain)
@@ -66,6 +86,15 @@ module ValidEmail2
       config = Resolv::DNS::Config.default_config_hash
       config[:nameserver] = @dns_nameserver if @dns_nameserver
       config
+    end
+
+    def generate_mx_cache_key(domain, domain_list, mx_servers)
+      return nil if mx_servers.empty? || domain_list.empty?
+
+      mx_servers_str = mx_servers.map(&:exchange).map(&:to_s).sort.join
+      return domain if mx_servers_str == ""
+
+      "#{domain_list.object_id}_#{domain_list.length}_#{mx_servers_str.downcase}"
     end
   end
 end

--- a/spec/benchmark_spec.rb
+++ b/spec/benchmark_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Performance testing" do
   let(:disposable_domain) { ValidEmail2.disposable_emails.first }
 
-  it "has acceptable lookup performance" do
+  it "disposable_domain? has acceptable lookup performance" do
     address = ValidEmail2::Address.new("test@example.com")
 
     # preload list and check size
@@ -13,6 +13,17 @@ describe "Performance testing" do
     expect(ValidEmail2.disposable_emails.count).to be > 30000
 
     # check lookup timing
-    expect { address.disposable_domain? }.to perform_under(0.0001).sample(10).times
+    expect { address.disposable_domain? }.to perform_under(0.0001).sec.sample(10).times
+  end
+
+  it "disposable_mx_server? has acceptable lookup performance" do
+    address = ValidEmail2::Address.new("test@gmail.com")
+
+    # preload list and check size
+    expect(ValidEmail2.disposable_emails).to be_a(Set)
+    expect(ValidEmail2.disposable_emails.count).to be > 30000
+
+    # check lookup timing
+    expect { address.disposable_mx_server? }.to perform_under(0.0001).sec.warmup(1).times.sample(10).times
   end
 end


### PR DESCRIPTION
This PR improves the performance of `disposable_mx_server?` for multiple queries about the same domain by caching the results.


### Background

In our case, email validation is performed on any user registration, including bulk registration. We found that comparing string endings of MX records against 160k+ domains in a loop takes a significant amount of time, which can be reduced if subsequent users share the same email domain.
