### PR TITLE
Do not modify config returned by Resolv::DNS::Config

### DIFF
--- a/lib/valid_email2/dns.rb
+++ b/lib/valid_email2/dns.rb
@@ -64,7 +64,7 @@ module ValidEmail2
 
     def resolv_config
       config = Resolv::DNS::Config.default_config_hash
-      config[:nameserver] = @dns_nameserver if @dns_nameserver
+      config = config.merge(nameserver: @dns_nameserver) if @dns_nameserver
       config
     end
   end

--- a/lib/valid_email2/dns.rb
+++ b/lib/valid_email2/dns.rb
@@ -64,6 +64,7 @@ module ValidEmail2
 
     def resolv_config
       config = Resolv::DNS::Config.default_config_hash
+      # REM: resolv gem 0.6.1 on linux can return frozen hash
       config = config.merge(nameserver: @dns_nameserver) if @dns_nameserver
       config
     end


### PR DESCRIPTION
While browsing latest gem changes I noticed that config returned by Resolv::DNS::Config.default_config_hash in 
https://github.com/micke/valid_email2/blob/dec511fab0c1a0f7da71c09aa5a3bbaa1e3ca43b/lib/valid_email2/dns.rb#L66-L67
is mutated.

This will be a problem with resolv gem 0.6.1 because on linux it can return frozen hash:
https://github.com/ruby/resolv/blob/6b57765f8ddc46b408aa3b222d1b372fdf1881b2/lib/resolv.rb#L1018
