### PR TITLE
remove salvationarmy.org

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -133102,7 +133102,6 @@ salutnaturalvita.es
 salvadomail.com
 salvador-nedv.ru
 salvatiojmail.ru
-salvationarmy.org
 salvationauto.com
 salvatore1818.site
 salvelinus.se


### PR DESCRIPTION
This is not a disposable email domain. It is used by our customers.