### PR TITLE
Remove samsung.com from disposable email domains

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -133780,7 +133780,6 @@ samsunaraccekici.com
 samsung-galaxy9.ru
 samsung-x5.online
 samsung.co.in
-samsung.com
 samsungacs.com
 samsunggalaxys9.cf
 samsunggalaxys9.ga


### PR DESCRIPTION
It's a valid email domain.
`https://raw.githubusercontent.com/FGRibreau/mailchecker/master/list.txt` and `https://raw.githubusercontent.com/disposable/disposable-email-domains/master/domains.txt` don't contain it.