### PR TITLE
Guard allow_listed? and disposable_domain? against unparseable addresses

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -82,11 +82,11 @@ module ValidEmail2
     end
 
     def disposable_domain?
-      domain_is_in?(address.domain, ValidEmail2.disposable_emails)
+      valid? && domain_is_in?(address.domain, ValidEmail2.disposable_emails)
     end
 
     def allow_listed?
-      domain_is_in?(address.domain, ValidEmail2.allow_list)
+      valid? && domain_is_in?(address.domain, ValidEmail2.allow_list)
     end
 
     def deny_listed?

--- a/spec/address_spec.rb
+++ b/spec/address_spec.rb
@@ -83,6 +83,11 @@ describe ValidEmail2::Address do
         address = described_class.new("foo@example.com")
         expect(address.disposable_domain?).to eq false
       end
+
+      it "is false if the email cannot be parsed" do
+        address = described_class.new('"><test>')
+        expect(address.disposable_domain?).to eq false
+      end
     end
 
     context "when the disposable domain has subdomains" do


### PR DESCRIPTION
Fixes #316.

`allow_listed?` and `disposable_domain?` call `address.domain` directly, so they raise `NoMethodError` when the address could not be parsed and `@address` is nil (for example `ValidEmail2::Address.new('"><test>')`). `deny_listed?` already guards with `valid?`, so this mirrors that and returns false for unparseable addresses instead of crashing.