### PR TITLE
Add endtest-mail.io as disposable email domain

### DIFF
--- a/config/disposable_email_domains.txt
+++ b/config/disposable_email_domains.txt
@@ -53238,6 +53238,7 @@ endozogkqq.site
 endpoint-hosting.online
 endritravels.com
 endrix.org
+endtest-mail.io
 enduranceblue-original.website
 endymion-numerique.com
 endzonebet.net


### PR DESCRIPTION
Adds endtest-mail.io to the disposable email domains list. Reference: https://endtest.io/mailbox