### PR TITLE
Validate domain hostname rules per label

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -11,6 +11,9 @@ module ValidEmail2
     PROHIBITED_DOMAIN_CHARACTERS_REGEX = /[+!_\/\s'#`]/
     DEFAULT_RECIPIENT_DELIMITER = '+'
     DOT_DELIMITER = '.'
+    HYPHEN_DELIMITER = '-'
+    MAX_DOMAIN_LENGTH = 253
+    MAX_LABEL_LENGTH = 63
 
     def self.prohibited_domain_characters_regex
       @prohibited_domain_characters_regex ||= PROHIBITED_DOMAIN_CHARACTERS_REGEX
@@ -52,13 +55,13 @@ module ValidEmail2
     def valid_domain?
       domain = address.domain
       return false if domain.nil?
+      return false if domain =~ self.class.prohibited_domain_characters_regex
+      return false if domain.length > MAX_DOMAIN_LENGTH
 
-      domain !~ self.class.prohibited_domain_characters_regex &&
-        domain.include?('.') &&
-        !domain.include?('..') &&
-        !domain.start_with?('.') &&
-        !domain.start_with?('-') &&
-        !domain.include?('-.')
+      labels = domain.split(DOT_DELIMITER, -1)
+      return false if labels.length < 2
+
+      labels.all? { |label| valid_domain_label?(label) }
     end
 
     def valid_address?
@@ -108,6 +111,14 @@ module ValidEmail2
     end
 
     private
+
+    # An RFC 1035 label: 1-63 octets, and it may not begin or end with a hyphen.
+    def valid_domain_label?(label)
+      !label.empty? &&
+        label.length <= MAX_LABEL_LENGTH &&
+        !label.start_with?(HYPHEN_DELIMITER) &&
+        !label.end_with?(HYPHEN_DELIMITER)
+    end
 
     def disposable_mx_server?
       mx_server_is_in?(ValidEmail2.disposable_emails)

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -171,6 +171,48 @@ describe ValidEmail2 do
       user = TestUser.new(email: "foo@example.com#")
       expect(user.valid?).to be_falsey
     end
+
+    describe "domain label structure" do
+      # A domain label may not begin or end with a hyphen and is limited to 63
+      # octets; the whole domain is limited to 253. These rules apply to every
+      # label, not only the first/last position of the domain string.
+      long_label = "a" * 64
+      long_domain = (["aa"] + ["a"] * 126).join(".") # 254 chars, all-valid labels
+
+      {
+        "a leading hyphen on the first label" => "foo@-example.com",
+        "a leading hyphen on a later label" => "foo@sub.-example.com",
+        "a leading hyphen on a deeply nested label" => "foo@a.b.-c.example.com",
+        "a trailing hyphen on a non-final label" => "foo@example-.com",
+        "a trailing hyphen on the final label" => "foo@example.com-",
+        "a bare hyphen label" => "foo@example.-.com",
+        "a label longer than 63 octets" => "foo@#{long_label}.com",
+        "a later label longer than 63 octets" => "foo@example.#{long_label}.com",
+        "a domain longer than 253 octets" => "foo@#{long_domain}"
+      }.each do |description, email|
+        it "is invalid with #{description}" do
+          expect(TestUser.new(email: email).valid?).to be_falsey
+        end
+      end
+
+      full_label = "a" * 63
+      max_domain = (["a"] * 127).join(".") # exactly 253 chars
+
+      {
+        "an internal hyphen" => "foo@ex-ample.com",
+        "hyphens on several internal labels" => "foo@f-o-o.example.com",
+        "a double internal hyphen" => "foo@a--b.example.com",
+        "a punycode (IDNA ACE) label" => "foo@xn--bcher-kva.com",
+        "a label beginning with a digit" => "foo@3m.com",
+        "a 63 octet label at the limit" => "foo@#{full_label}.com",
+        "a later 63 octet label" => "foo@example.#{full_label}.com",
+        "a domain at the 253 octet limit" => "foo@#{max_domain}"
+      }.each do |description, email|
+        it "is valid with #{description}" do
+          expect(TestUser.new(email: email).valid?).to be_truthy
+        end
+      end
+    end
   end
 
   describe "with disposable validation" do


### PR DESCRIPTION
`valid_domain?` checks the hostname rules positionally against the whole domain string instead of per label. It rejects a leading hyphen only via `start_with?('-')` (first label only) and a trailing hyphen only via `include?('-.')` (a hyphen followed by a dot, i.e. non-final labels only), and it has no length check at all. So the mirror positions leak through:

```ruby
ValidEmail2::Address.new("user@foo.-bar.com").valid?  # => true  (leading hyphen, later label)
ValidEmail2::Address.new("user@example.com-").valid?  # => true  (trailing hyphen, final label)
ValidEmail2::Address.new("user@#{'a' * 64}.com").valid?  # => true  (label > 63 octets)
ValidEmail2::Address.new("user@#{(['a'] * 127).join('.')}a").valid?  # => true  (domain > 253 octets)
```

The spec already asserts that a domain may not begin or end with a dash (`"is invalid if the domain begins with a dash"` / `"...ends with a dash"`). These are the same rule applied to every label rather than only the first and last position of the domain string, plus the RFC 1035 length limits (63 per label, 253 total). Python's `email_validator` rejects all four shapes.

The fix splits the domain on `.` and validates each label (1–63 octets, no leading or trailing hyphen) plus the overall 253-octet limit. Internal hyphens, double hyphens (`a--b`) and punycode labels (`xn--bcher-kva`) stay valid — only the boundary positions of each label are checked, so no legitimate hostname is affected.

This is scoped to label *structure* and length; it does not touch `PROHIBITED_DOMAIN_CHARACTERS_REGEX` (the separate character-set surface). It uses the existing string/regex approach rather than a full IDNA library — labels are counted in characters, which matches how the rest of `valid_domain?` already works.

Tests: added a parametrized table of the malformed shapes (invalid) alongside the internal-hyphen / double-hyphen / punycode / 63-octet / 253-octet cases that must stay valid. Full suite green (`bundle exec rake`).
